### PR TITLE
Load layouts from /layouts

### DIFF
--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -40,7 +40,7 @@ class ComPagesModelEntityPage extends KModelEntityAbstract
                 'process'     => array(
                     'plugins' => true
                 ),
-                'layout'      => 'default'
+                'layout'      => ''
             ),
         ));
 

--- a/code/site/components/com_pages/template/locator.php
+++ b/code/site/components/com_pages/template/locator.php
@@ -44,9 +44,8 @@ class ComPagesTemplateLocator extends KTemplateLocatorFile
     {
         $path = ltrim(str_replace(parse_url($info['url'], PHP_URL_SCHEME).'://', '', $info['url']), '/');
 
-        $file   = pathinfo($path, PATHINFO_FILENAME);
-        $format = pathinfo($path, PATHINFO_EXTENSION);
-        $path   = ltrim(pathinfo($path, PATHINFO_DIRNAME), '.');
+        $file = pathinfo($path, PATHINFO_FILENAME);
+        $path = ltrim(pathinfo($path, PATHINFO_DIRNAME), '.');
 
         //Prepend the base path
         if($path) {
@@ -56,9 +55,9 @@ class ComPagesTemplateLocator extends KTemplateLocatorFile
         }
 
         if($this->realPath($path.'/'.$file)) {
-            $pattern = $path.'/'.$file.'/index.'.$format.'*';
+            $pattern = $path.'/'.$file.'/index.'.'*';
         } else {
-            $pattern = $path.'/'.$file.'.'.$format.'*';
+            $pattern = $path.'/'.$file.'.*';
         }
 
         //Try to find the file

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -38,7 +38,7 @@ class ComPagesViewPageHtml extends ComKoowaViewHtml
                 throw new RuntimeException(sprintf("Layout '%s' cannot be found", $layout));
             }
         }
-        else $path = 'com:pages.view.page.default.html';
+        else $path = 'com://site/pages.page.default.html';
 
         $context->layout = $path;
     }

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -65,26 +65,28 @@ class ComPagesViewPageHtml extends ComKoowaViewPageHtml
             $content = new stdClass;
             $content->text = $context->result;
 
+            $params = (object)$page->getProperties();
+
             //Trigger onContentBeforeDisplay
             $results = array();
             $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
                 'name'         => 'onContentBeforeDisplay',
                 'import_group' => 'content',
-                'attributes'   => array('com_pages.page', &$content, (object)$page->getProperties())
+                'attributes'   => array('com_pages.page', &$content, &$params)
             ));
 
             //Trigger onContentPrepare
             $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
                 'name'         => 'onContentPrepare',
                 'import_group' => 'content',
-                'attributes'   => array('com_pages.page', &$content, (object)$page->getProperties())
+                'attributes'   => array('com_pages.page', &$content, &$params)
             ));
 
             //Trigger onContentAfterDisplay
             $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
                 'name'         => 'onContentAfterDisplay',
                 'import_group' => 'content',
-                'attributes'   => array('com_pages.page', &$content, (object)$page->getProperties())
+                'attributes'   => array('com_pages.page', &$content, &$params)
             ));
 
             $context->result = trim(implode("\n", $results));;

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -32,15 +32,34 @@ class ComPagesViewPageHtml extends ComKoowaViewHtml
         //Find the layout
         if($layout = $context->data->page->layout)
         {
-            $format = $this->getFormat();
             $path = 'page://layouts/'.$layout;
 
-            if (!$this->getObject('template.locator.factory')->locate($path.'.'.$format)) {
+            if (!$this->getObject('template.locator.factory')->locate($path)) {
                 throw new RuntimeException(sprintf("Layout '%s' cannot be found", $layout));
             }
-
-            $context->layout = $path;
         }
+        else $path = 'com:pages.view.page.default.html';
+
+        $context->layout = $path;
+    }
+
+    /**
+     * Return the views output
+     *
+     * @param KViewContext  $context A view context object
+     * @return string  The output of the view
+     */
+    protected function _actionRender(KViewContext $context)
+    {
+        $data = KObjectConfig::unbox($context->data);
+
+        //Render the template
+        $this->_content = $this->getTemplate()
+            ->loadFile($context->layout)
+            ->setParameters($context->parameters)
+            ->render($data);
+
+        return KViewAbstract::_actionRender($context);
     }
 
     protected function _processPlugins(KViewContextInterface $context)

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-framework-pages for the canonical source repository
  */
 
-class ComPagesViewPageHtml extends ComKoowaViewHtml
+class ComPagesViewPageHtml extends ComKoowaViewPageHtml
 {
     public function __construct(KObjectConfig $config)
     {

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -43,12 +43,6 @@ class ComPagesViewPageHtml extends ComKoowaViewPageHtml
         $context->layout = $path;
     }
 
-    /**
-     * Return the views output
-     *
-     * @param KViewContext  $context A view context object
-     * @return string  The output of the view
-     */
     protected function _actionRender(KViewContext $context)
     {
         $data = KObjectConfig::unbox($context->data);
@@ -68,7 +62,8 @@ class ComPagesViewPageHtml extends ComKoowaViewPageHtml
 
         if($page->process->plugins)
         {
-            $content = $context->result;
+            $content = new stdClass;
+            $content->text = $context->result;
 
             //Trigger onContentBeforeDisplay
             $results = array();

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -25,6 +25,24 @@ class ComPagesViewPageHtml extends ComKoowaViewHtml
         parent::_initialize($config);
     }
 
+    protected function _fetchData(KViewContext $context)
+    {
+        parent::_fetchData($context);
+
+        //Find the layout
+        if($layout = $context->data->page->layout)
+        {
+            $format = $this->getFormat();
+            $path = 'page://layouts/'.$layout;
+
+            if (!$this->getObject('template.locator.factory')->locate($path.'.'.$format)) {
+                throw new RuntimeException(sprintf("Layout '%s' cannot be found", $layout));
+            }
+
+            $context->layout = $path;
+        }
+    }
+
     protected function _processPlugins(KViewContextInterface $context)
     {
         $page = $context->data->page;


### PR DESCRIPTION
If a layout is defined in the page frontmatter it's loaded from the /layouts folder. If no layout is defined the default layout that is part of the component is loaded. 

The layout is is a relative path and can include subfolders. Example

- layout: file
- layout: folder/file

The layout follows the same naming conventions as the page, and is auto-discovered. The specific template engine is loaded based on the filename suffix.

### Notes

1. As part of this change page template files no longer require to have a format suffix eg '.html'. 

2. As part of this change the module filter is now also available, this means that you can make use of the` <ktml:module position="[position]">[content]</ktml:module> `syntax to insert modules on the fly. 

The module filter should also be documented as it's very powerful. Code can be found here: [koowa/template/filter/module.php](https://github.com/joomlatools/joomlatools-framework/blob/master/code/libraries/joomlatools/component/koowa/template/filter/module.php)