### PR TITLE
Add theme:// template locator

### DIFF
--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -13,7 +13,8 @@ return array(
         'template.locator.factory' => [
             'locators' => [
                 'com:pages.data.locator',
-                'com:pages.template.locator'
+                'com:pages.template.locator.page',
+                'com:pages.template.locator.theme'
             ]
         ],
         'template.engine.factory' => [

--- a/code/site/components/com_pages/template/locator/page.php
+++ b/code/site/components/com_pages/template/locator/page.php
@@ -7,23 +7,10 @@
  * @link        https://github.com/joomlatools/joomlatools-framework-pages for the canonical source repository
  */
 
-class ComPagesTemplateLocator extends KTemplateLocatorFile
+class ComPagesTemplateLocatorPage extends KTemplateLocatorFile
 {
-    /**
-     * The locator name
-     *
-     * @var string
-     */
     protected static $_name = 'page';
 
-    /**
-     * Initializes the options for the object
-     *
-     * Called from {@link __construct()} as a first step of object instantiation.
-     *
-     * @param  KObjectConfig $config  An optional ObjectConfig object with configuration options.
-     * @return void
-     */
     protected function _initialize(KObjectConfig $config)
     {
         $config->append(array(
@@ -33,13 +20,6 @@ class ComPagesTemplateLocator extends KTemplateLocatorFile
         parent::_initialize($config);
     }
 
-    /**
-     * Find a template path
-     *
-     * @param array  $info  The path information
-     * @throws RuntimeException If the no base path exists while trying to locate a partial.
-     * @return string|false The real template path or FALSE if the template could not be found
-     */
     public function find(array $info)
     {
         $path = ltrim(str_replace(parse_url($info['url'], PHP_URL_SCHEME).'://', '', $info['url']), '/');

--- a/code/site/components/com_pages/template/locator/theme.php
+++ b/code/site/components/com_pages/template/locator/theme.php
@@ -7,19 +7,16 @@
  * @link        https://github.com/joomlatools/joomlatools-framework-pages for the canonical source repository
  */
 
-class ComPagesTemplate extends KTemplate
+class ComPagesTemplateLocatorTheme extends KTemplateLocatorFile
 {
+    protected static $_name = 'theme';
+
     protected function _initialize(KObjectConfig $config)
     {
-        $config->append(array(
-            'functions'  => array(
-                'data' => function($path, $format = '') {
-                    return  $this->getObject('com:pages.data.factory')->createObject($path, $format);
-                }
+        $template  = JFactory::getApplication()->getTemplate();
 
-            ),
-            'cache'           => false,
-            'cache_namespace' => 'pages',
+        $config->append(array(
+            'base_path' =>  JPATH_THEMES.'/'.$template,
         ));
 
         parent::_initialize($config);


### PR DESCRIPTION
Allow to import templates from within the active theme. Use theme:// 

Example:

`import('theme/includes/file')`

Will include the following file `/root/templates/[active]/includes/file` where `[active]` is the active template in Joomla.

