### PR TITLE
HTTP caching

### DIFF
--- a/code/site/components/com_pages/controller/page.php
+++ b/code/site/components/com_pages/controller/page.php
@@ -57,6 +57,7 @@ class ComPagesControllerPage extends KControllerModel
 
     protected function _afterRender(KControllerContextInterface $context)
     {
+        //Set metadata
         if($context->request->getFormat() == 'html')
         {
             //Set the metadata
@@ -66,6 +67,18 @@ class ComPagesControllerPage extends KControllerModel
 
             //Set the title
             JFactory::getDocument()->setTitle($this->getView()->getTitle());
+        }
+
+        //Disable caching
+        if($page = $this->getObject('com:pages.router')->getPage())
+        {
+            if($page->cache !== false)
+            {
+                if($page->has('cache_time')) {
+                    $context->request->headers->set('Cache-Control', array('max_age' => $page->get('cache_time')));
+                }
+            }
+            else $context->request->headers->set('Cache-Control', 'no-cache');
         }
     }
 }

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -100,7 +100,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
             if($file = $this->getObject('com:pages.data.locator')->locate('data://'.$basepath.'/.order'))
             {
                 if(isset($this->fromFile($file)['directories'])) {
-                    $files = $this->_orderData($files, $this->fromFile($file)['directories']);
+                    $dirs = $this->_orderData($dirs, $this->fromFile($file)['directories']);
                 }
             }
 

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -20,9 +20,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
     protected function _initialize(KObjectConfig $config)
     {
         $config->append(array(
-            'cache'         => false,
-            'cache_private' => false,
-            'cache_time'    => 15, //must revalidate
+            'cache_time' => 7200, //2h
         ));
 
         parent::_initialize($config);

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
+{
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        $this->getObject('event.publisher')
+            ->addListener('onAfterApplicationRespond', array($this, 'onAfterApplicationRespond'));
+    }
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'cache'         => false,
+            'cache_private' => false,
+            'cache_time'    => 15, //must revalidate
+        ));
+
+        parent::_initialize($config);
+    }
+
+    protected function _beforeDispatch(KDispatcherContextInterface $context)
+    {
+        if($this->isCacheable())
+        {
+            if($data = $this->_getCache()->get($this->_getCacheKey()))
+            {
+                $content = $this->_prepareContent($data['content']);
+                $headers = $this->_prepareHeaders($data['headers']);
+
+                if(!$this->getObject('lib:http.response', ['headers' => $headers])->isStale())
+                {
+                    $this->getObject('response')
+                        ->setHeaders($headers)
+                        ->setContent($content);
+
+                    $this->send();
+
+                    return false;
+                }
+            }
+            //Create a buffer to capture output for caching
+            else ob_start();
+        }
+    }
+
+    protected function _beforeFlush(KDispatcherContextInterface $context)
+    {
+        //Proxy Koowa Output
+        if($this->isCacheable() && $this->getResponse()->isCacheable() && !$this->getResponse()->isStale())
+        {
+            $data = array(
+                'headers' => $this->getResponse()->getHeaders(),
+                'content' => $this->getResponse()->getContent()
+            );
+
+            $this->_getCache()->store($data, $this->_getCacheKey());
+        }
+    }
+
+    public function onAfterApplicationRespond(KEventInterface $event)
+    {
+        //Proxy Joomla Output
+        if($this->isCacheable() && $this->getResponse()->isCacheable() && !$this->getResponse()->isStale())
+        {
+            $data = array(
+                'headers' => $this->getResponse()->getHeaders(),
+                'content' => $this->getResponse()->getContent()
+            );
+
+            $this->_getCache()->store($data, $this->_getCacheKey());
+        }
+    }
+
+    protected function _getCache()
+    {
+        if (!$this->__cache)
+        {
+            $options = array(
+                'caching'       => true,
+                'defaultgroup'  => 'com_koowa.pages',
+                'lifetime'      => 60*24*7, //1 week
+            );
+
+            $this->__cache = JCache::getInstance('output', $options);
+        }
+
+        return $this->__cache;
+    }
+
+    protected function _getCacheKey()
+    {
+        $url    = $this->getRequest()->getUrl();
+        $format = $this->getRequest()->getFormat();
+        $user   = $this->getUser()->getId();
+
+        return crc32($url.$format.$user);
+    }
+
+    protected function _getContent()
+    {
+        return ob_get_clean();
+    }
+
+    protected function _getHeaders()
+    {
+        $headers = array();
+
+        //Remove headers set by Joomla
+        header_remove('Pragma');
+        header_remove('Last-Modified');
+        header_remove('Expires');
+
+        $headers = array();
+        foreach (headers_list() as $header)
+        {
+            $parts = explode(':', $header, 2);
+            $headers[trim($parts[0])] = trim($parts[1]);
+        }
+
+        return $headers;
+    }
+
+    protected function _prepareContent($content)
+    {
+        //Search for a token in the content and refresh it
+        $token       = JSession::getFormToken();
+        $search      = '#<input type="hidden" name="[0-9a-f]{32}" value="1" />#';
+        $replacement = '<input type="hidden" name="' . $token . '" value="1" />';
+
+        return preg_replace($search, $replacement, $content);
+    }
+
+    protected function _prepareHeaders($headers)
+    {
+        return $headers;
+    }
+}

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -97,7 +97,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
 
     protected function _getCacheKey()
     {
-        $url    = $this->getRequest()->getUrl();
+        $url    = $this->getRequest()->getUrl()->toString(KHttpUrl::HOST + KHttpUrl::PATH + KHttpUrl::QUERY);
         $format = $this->getRequest()->getFormat();
         $user   = $this->getUser()->getId();
 

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -9,6 +9,15 @@
 
 class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
 {
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'behaviors' => ['cacheable'],
+        ]);
+
+        parent::_initialize($config);
+    }
+
     protected function _beforeDispatch(KDispatcherContextInterface $context)
     {
         $request = $context->request;

--- a/code/site/components/com_pages/pages.php
+++ b/code/site/components/com_pages/pages.php
@@ -17,4 +17,3 @@ try {
 } catch(Exception $exception) {
     KObjectManager::getInstance()->getObject('exception.handler')->handleException($exception);
 }
-}

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -42,9 +42,9 @@ return array(
             }
         ],
         'com://site/pages.dispatcher.behavior.cacheable' => [
-            'cache'         => $config['cache'] ?: false,
-            'cache_time'    => $config['cache_time'] ?: 0,
-            'cache_private' => $config['cache_private'] ?: false,
+            'cache'         => $config['cache'] ?? false,
+            'cache_time'    => $config['cache_time'] ?? 0,
+            'cache_private' => $config['cache_private'] ?? false,
         ]
     ]
 );

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -7,6 +7,11 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
+$config = array();
+if(file_exists(Koowa::getInstance()->getRootPath().'/joomlatools-pages/config.php')) {
+    $config = (array) include Koowa::getInstance()->getRootPath().'/joomlatools-pages/config.php';
+}
+
 return array(
 
     'aliases' => [
@@ -36,5 +41,10 @@ return array(
                 return \Michelf\MarkdownExtra::defaultTransform($text);
             }
         ],
+        'com://site/pages.dispatcher.behavior.cacheable' => [
+            'cache'         => $config['cache'] ?: false,
+            'cache_time'    => $config['cache_time'] ?: 0,
+            'cache_private' => $config['cache_private'] ?: false,
+        ]
     ]
 );

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -18,7 +18,6 @@ return array(
         'object.config.factory' => [
             'formats' => ['md' => 'ComPagesDataMarkdown']
         ],
-
         'template.locator.factory' => [
             'locators' => [
                 'com:pages.data.locator',
@@ -36,6 +35,6 @@ return array(
                 //See: https://michelf.ca/projects/php-markdown/extra/
                 return \Michelf\MarkdownExtra::defaultTransform($text);
             }
-        ]
+        ],
     ]
 );

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesViewHtml extends ComKoowaViewPageHtml
+class ComPagesViewHtml extends ComKoowaViewHtml
 {
     protected function _initialize(KObjectConfig $config)
     {


### PR DESCRIPTION
Implement http caching support through cacheable dispatcher behavior.  

This PR requires: https://github.com/joomlatools/joomlatools-framework/pull/180 and https://github.com/joomlatools/joomlatools-framework/pull/183 

It's best to read up on https://github.com/joomlatools/joomlatools-framework/issues/36 to if you are not familiar with http caching

## Browser Caching

See: https://github.com/joomlatools/joomlatools-framework/pull/183

## Server caching

Implemented a server side caching mechanism through the build in Joomla caching adapters. 

#### Cache key

The server side cache key is based on the url, user and format, by not using the contents of the page we can return the response from cache for subsequent requests for the same resource. The longer our max-age, the longer the resource will remain valid in our server cache. 

#### Invalidation

Using a passive cache cleanup mechanism. Files are stored on disk for max 1 week, after which they are garbage collected. This ensure that local cache is cleared for url's that are not requested, or no longer exists. 

## Configuration

Configuration is provided at two levels:

#### 1. Global 

Globally the cache can be configured by adding a docman.php file to the /joomla-pages root folder with the following config options:

    <?php
      return array(
         'cache'         => true,
         'cache_time'    => 7200, //(seconds)
         'cache_private' => false,
    );

#### 2. Page

The cache can be disabled per page and the cache_time can also be set.  The page specific properties are

- cache: false
- cache_time: 7200 //(seconds)