### PR TITLE
Page decoration

### DIFF
--- a/code/site/components/com_pages/controller/page.php
+++ b/code/site/components/com_pages/controller/page.php
@@ -56,7 +56,9 @@ class ComPagesControllerPage extends KControllerModel
             }
 
             //Set the title
-            JFactory::getDocument()->setTitle($this->getView()->getTitle());
+            if($title = $this->getView()->getTitle()) {
+                JFactory::getDocument()->setTitle($title);
+            }
         }
 
         //Disable caching

--- a/code/site/components/com_pages/controller/page.php
+++ b/code/site/components/com_pages/controller/page.php
@@ -45,16 +45,6 @@ class ComPagesControllerPage extends KControllerModel
         return $formats;
     }
 
-    protected function _beforeRender(KControllerContextInterface $context)
-    {
-        //Set the entity content in the response to allow for view decoration
-        if($context->request->getFormat() == 'html')
-        {
-            $entity = $this->getModel()->fetch();
-            $context->response->setContent($entity->content);
-        }
-    }
-
     protected function _afterRender(KControllerContextInterface $context)
     {
         //Set metadata

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -52,6 +52,28 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
         }
     }
 
+    protected function _beforeSend(KDispatcherContextInterface $context)
+    {
+        if($this->isCacheable())
+        {
+            //Disable caching
+            if ($page = $context->request->query->get('page', 'url', false))
+            {
+                $page = $this->getObject('page.registry')->getPage($page);
+
+                if ($page->cache !== false)
+                {
+                    if ($page->has('cache_time')) {
+                        $this->getMixer()->getResponse()->setMaxAge($page->get('cache_time'));
+                    }
+                }
+                else $this->getConfig()->cache = false;
+            }
+        }
+
+        parent::_beforeSend($context);
+    }
+
     protected function _beforeFlush(KDispatcherContextInterface $context)
     {
         //Proxy Koowa Output

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -25,21 +25,7 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
         //Manualy route the url if it hasn't been routed yet
         if(!isset($request->query->path))
         {
-            $base = $request->getBasePath();
-            $url  = $request->getUrl()->getPath();
-
-            //Get the segments
-            $path = trim(str_replace(array($base, '/index.php'), '', $url), '/');
-
-            if($path) {
-                $segments = explode('/', $path);
-            } else {
-                $segments = array('index');
-            }
-
-            //Route the
-            $query = $this->getObject('com:pages.router')->parse($segments);
-
+            $query = $this->getObject('com:pages.router')->route();
             $request->query->add($query);
         }
     }

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -20,23 +20,19 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
 
     protected function _beforeDispatch(KDispatcherContextInterface $context)
     {
-        $request = $context->request;
+        //Get the route
+        $route = $this->getObject('com:pages.router')->getRoute();
 
-        //Manualy route the url if it hasn't been routed yet
-        if(!isset($request->query->path))
-        {
-            $query = $this->getObject('com:pages.router')->parse();
-            $request->query->add($query);
+        //Throw 4054 if the page cannot be found
+        if($query = $this->getObject('com:pages.router')->parse($route)) {
+            $context->request->query->add($query);
+        } else {
+            throw new KHttpExceptionNotFound('Page Not Found');
         }
     }
 
     protected function _actionDispatch(KDispatcherContextInterface $context)
     {
-        //Throw 404 if the route is not valid
-        if(!$this->getObject('com:pages.router')->getPage()) {
-            throw new KHttpExceptionNotFound('Page Not Found');
-        }
-
         //Throw 405 if the method is not allowed
         $method = strtolower($context->request->getMethod());
         if (!in_array($method, $this->getHttpMethods())) {

--- a/code/site/components/com_pages/event/subscriber/decorator.php
+++ b/code/site/components/com_pages/event/subscriber/decorator.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesEventSubscriberDecorator extends KEventSubscriberAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'priority' => KEvent::PRIORITY_HIGH
+        ));
+
+        parent::_initialize($config);
+    }
+
+    public function onAfterApplicationDispatch(KEventInterface $event)
+    {
+        $option = $this->getObject('request')->query->get('option', 'cmd');
+        $route  = $this->getObject('com:pages.router')->route();
+
+        if($route['page'] && $option != 'com_pages' )
+        {
+            $buffer = $event->getTarget()->getDocument()->getBuffer('component');
+
+            ob_start();
+
+            $dispatcher = $this->getObject('com://site/pages.dispatcher.http');
+            $dispatcher->getResponse()->setContent($buffer);
+            $dispatcher->dispatch();
+
+            $result = ob_get_clean();
+
+            $event->getTarget()->getDocument()->setBuffer($result, 'component');
+        }
+    }
+}

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -98,6 +98,8 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         $page = null;
         $file = false;
 
+        $path = ltrim($path, './');
+
         if($path && !isset($this->__page[$path]))
         {
             $file = $this->getObject('com:pages.page.locator')->locate('page://pages/'. $path);

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -35,6 +35,9 @@ return array(
                 'lib:template.engine.markdown',
             ]
         ],
+        'event.subscriber.factory' => [
+            'subscribers' => ['com:pages.event.subscriber.decorator']
+        ],
         'lib:template.engine.markdown' => [
             'compiler' => function($text) {
                 //See: https://michelf.ca/projects/php-markdown/extra/

--- a/code/site/components/com_pages/router.php
+++ b/code/site/components/com_pages/router.php
@@ -11,6 +11,26 @@ class ComPagesRouter extends KObject implements KObjectSingleton
 {
     private $__page = false;
 
+    public function route()
+    {
+        $request = $this->getObject('request');
+
+        $base = $request->getBasePath();
+        $url  = $request->getUrl()->getPath();
+
+        //Get the segments
+        $path = trim(str_replace(array($base, '/index.php'), '', $url), '/');
+
+        if($path) {
+            $segments = explode('/', $path);
+        } else {
+            $segments = array('index');
+        }
+
+        //Route
+        return $this->parse($segments);
+    }
+
     public function build(&$query)
     {
         $segments = array();

--- a/code/site/components/com_pages/router.php
+++ b/code/site/components/com_pages/router.php
@@ -67,6 +67,7 @@ class ComPagesRouter extends KObject implements KObjectSingleton
                 $query['format'] = $format;
                 $route = basename($route, '.' . $format);
             }
+            else $route = $page;
 
             $query['page'] = $page;
 

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -37,7 +37,7 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
     {
         $result = '';
         if($page = $this->getPage()) {
-            $result = $page->title ? $page->title :  parent::getTitle();
+            $result = $page->title ? $page->title :  '';
         }
 
         return $result;
@@ -53,7 +53,7 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
             }
 
             //Set the description into the metadata if it doesn't exist.
-            if(isset($page->summary) && !isset($page->metadata->description)) {
+            if(!empty($page->summary) && !isset($page->metadata->description)) {
                 $metadata['description'] = $page->summary;
             }
         }


### PR DESCRIPTION
This PR implements the ability to decorate  an existing Joomla menu item or page. The Joomla rendering cycle is intercepted after the active component has been dispatched and the returned by the  component is then injected in a page to be decorated.

### Setup

To decorate an existing menu item or page create a page with the same name as the menu item alias, or the page route.

Example: `http://mysite.com/path/to/menu` => `/joomlatools-pages/pages/path/to/menu`

In the page place a `<ktml:content>` which will acted as the placeholder for output generated by the component and then place mark around it. The decorated result will be injected back into Joomla after processing.

### Notes

- Frontmatter defined in the page will overwrite the Joomla menu item settings. If no frontmatter is defined the menu settings will be used. Example:

```yaml
title: Title override
summery: Description override
```

- A menu item exists in the Joomla menu structure and is linked to a component, a page doesn't exist in the Joomla menu structure it's generated by the component. 

For example:  `http://mysite/[articles]/[uncategorised/myarticle]`

- `articles` is a menu item that links to the Joomla content component using an '_List All Categories_' menu type. 

- `uncategorised/myarticle`is a page generated by the content component. It shows the article with alias myarticle that is part of the `uncategorised` category.