### PR TITLE
Implement page ordering support

### DIFF
--- a/code/site/components/com_pages/dispatcher/router/route.php
+++ b/code/site/components/com_pages/dispatcher/router/route.php
@@ -130,6 +130,6 @@ class ComPagesDispatcherRouterRoute extends KDispatcherRouterRoute
         $url  = $this->getObject('request')->getUrl()->getPath();
 
         //Get the route
-        return trim(str_replace(array($base, '/index.php'), '', '/'.$url), '/');
+        return trim(str_replace(array($base, '/index.php'), '', $url), '/');
     }
 }

--- a/code/site/components/com_pages/model/behavior/sortable.php
+++ b/code/site/components/com_pages/model/behavior/sortable.php
@@ -23,7 +23,7 @@ class ComPagesModelBehaviorSortable extends KModelBehaviorAbstract
         parent::onMixin($mixer);
 
         $mixer->getState()
-            ->insert('sort', 'cmd', 'title')
+            ->insert('sort', 'cmd', 'order')
             ->insert('order', 'word', 'asc');
     }
 
@@ -35,7 +35,7 @@ class ComPagesModelBehaviorSortable extends KModelBehaviorAbstract
         {
             $pages = KObjectConfig::unbox($context->pages);
 
-            if($state->sort)
+            if($state->sort && $state->sort != 'order')
             {
                 usort($pages, function($first, $second) use($state)
                 {


### PR DESCRIPTION
Pages can be ordered per folder by adding a .order.[format] file to the folder that specifies the specific ordering of all the data files, both files and directories can be ordered.`Type`can be any data format: YAML, JSON, INI, PHP, and XML.

Example with YAML:

```yaml
- file1.md
- fileB.md
- folderA
- folderB
```
