### PR TITLE
Improve page and data registry cache

### DIFF
--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -25,6 +25,22 @@ class ComPagesDataObject extends KObjectConfig
         return new self($data);
     }
 
+    public function flatten()
+    {
+        $data = array();
+
+        foreach( $this->toArray() as $key => $values)
+        {
+            if(is_array($values)) {
+                $data = array_merge($data, $values);
+            } else {
+                $data[] = $values;
+            }
+        }
+
+        return new self($data);
+    }
+
     public function filter($key, $value = null)
     {
         $data = $this->toArray();

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -30,7 +30,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         $this->_cache_time = $config->cache_time;
 
         if(empty($config->cache_path)) {
-            $this->_cache_path = $this->getObject('com:pages.page.locator')->getBasePath().'/cache';
+            $this->_cache_path = Koowa::getInstance()->getRootPath().'/joomlatools-pages/cache';
         } else {
             $this->_cache_path = $config->cache_path;
         }

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -9,8 +9,12 @@
 
 final class ComPagesDataRegistry extends KObject implements KObjectSingleton
 {
-    private $__data     = array();
-    private  $__locator = null;
+    private $__data    = array();
+    private $__locator = null;
+
+    protected $_cache;
+    protected $_cache_path;
+    protected $_cache_time;
 
     public function __construct(KObjectConfig $config)
     {
@@ -18,6 +22,29 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
 
         //Create the locator
         $this->__locator = $this->getObject('com:pages.data.locator');
+
+        //Set the cache
+        $this->_cache = $config->cache;
+
+        //Set the cache time
+        $this->_cache_time = $config->cache_time;
+
+        if(empty($config->cache_path)) {
+            $this->_cache_path = $this->getObject('com:pages.page.locator')->getBasePath().'/cache';
+        } else {
+            $this->_cache_path = $config->cache_path;
+        }
+    }
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'cache'      => true,
+            'cache_path' => '',
+            'cache_time' => 60*60*24 //1 day
+        ]);
+
+        parent::_initialize($config);
     }
 
     public function getLocator()
@@ -27,39 +54,61 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
 
     public function getData($path, $format = '')
     {
+        $result = array();
         if(!isset($this->__data[$path]))
         {
-            if(!parse_url($path, PHP_URL_SCHEME) == 'http')
-            {
-                //Locate the data file
-                if (!$file = $this->getLocator()->locate('data://'.$path)) {
-                    throw new InvalidArgumentException(sprintf('The data file "%s" cannot be located.', $path));
-                }
+            $segments = explode('/', $path);
+            $root     = array_shift($segments);
 
-                if(is_dir($file)) {
-                    $result = $this->fromDirectory($file);
-                } else {
-                    $result = $this->fromFile($file);
+            //Load the cache and do not refresh it
+            $data = $this->loadCache($root, false);
+
+            foreach($segments as $segment)
+            {
+                if(!isset($data[$segment]))
+                {
+                    $data = array();
+                    break;
                 }
+                else $data = $data[$segment];
             }
-            else $result = $this->fromUrl($path, $format);
 
             //Create the data object
             $class = $this->getObject('manager')->getClass('com:pages.data.object');
-            $this->__data[$path] = new $class($result);
+            $this->__data[$path] = new $class($data);
         }
 
         return $this->__data[$path];
     }
 
-    public function fromFile($file)
+    private function __fromPath($path, $format = '')
+    {
+        if(!parse_url($path, PHP_URL_SCHEME) == 'http')
+        {
+            //Locate the data file
+            if (!$file = $this->getLocator()->locate('data://'.$path)) {
+                throw new InvalidArgumentException(sprintf('The data "%s" does not exist.', $path));
+            }
+
+            if(is_dir($file)) {
+                $result = $this->__fromDirectory($file);
+            } else {
+                $result = $this->__fromFile($file);
+            }
+        }
+        else $result = $this->__fromUrl($path, $format);
+
+        return $result;
+    }
+
+    private function __fromFile($file)
     {
         //Get the data
         $result = array();
 
         $url = trim(fgets(fopen($file, 'r')));
         if(strpos($url, '://') === 0) {
-            $result = $this->fromUrl($url, pathinfo($file, PATHINFO_EXTENSION));
+            $result = $this->__fromUrl($url, pathinfo($file, PATHINFO_EXTENSION));
         } else {
             $result = $this->getObject('object.config.factory')->fromFile($file, false);
         }
@@ -67,7 +116,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         return $result;
     }
 
-    public function fromDirectory($path)
+    private function __fromDirectory($path)
     {
         $data  = array();
         $nodes = array();
@@ -79,7 +128,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         foreach (new DirectoryIterator($path) as $node)
         {
             if(strpos($node->getFilename(), '.order.') !== false) {
-                $nodes = array_merge($this->fromFile((string)$node->getFileInfo()), $nodes);
+                $nodes = array_merge($this->__fromFile((string)$node->getFileInfo()), $nodes);
             }
 
             if (!in_array($node->getFilename()[0], array('.', '_'))) {
@@ -97,29 +146,29 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
             $info = pathinfo($node);
 
             if($info['extension']) {
-                $files[] = $node;
+                $files[$info['filename']] = $basepath.'/'.$node;
             } else {
-                $dirs[] = $node;
+                $dirs[$node] = $basepath.'/'.$node;
             }
         }
 
-        foreach($files as $file)
+        foreach($files as $name => $file)
         {
-            if(count($files) > 1) {
-                $data[] = $this->getData($basepath.'/'.$file);
+            if($name !== basename(dirname($file))) {
+                $data[$name] = $this->__fromPath($file);
             } else {
-                $data = $this->getData($basepath.'/'.$file);
+                $data = $this->__fromPath($file);
             }
         }
 
-        foreach($dirs as $dir) {
-            $data[basename($dir)] = $this->getData($basepath.'/'.$dir);
+        foreach($dirs as $name => $dir) {
+            $data[$name] = $this->__fromPath($dir);
         }
 
         return $data;
     }
 
-    public function fromUrl($url, $format = '')
+    private function __fromUrl($url, $format = '')
     {
         if(!ini_get('allow_url_fopen')) {
             throw new RuntimeException(sprintf('Cannot open url: "%s".', $url));
@@ -148,6 +197,96 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         }
 
         $result = $this->getObject('object.config.factory')->fromString($format, $content, false);
+        return $result;
+    }
+
+    public function buildCache()
+    {
+        if($this->_cache)
+        {
+            $basedir = $this->getLocator()->getBasePath();
+
+            foreach (new DirectoryIterator($basedir) as $node)
+            {
+                if (!in_array($node->getFilename()[0], array('.', '_'))) {
+                    $this->loadCache(pathinfo($node, PATHINFO_FILENAME), true);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function loadCache($basedir, $refresh = true)
+    {
+        if (!$cache = $this->isCached($basedir))
+        {
+            $data = $this->__fromPath($basedir);
+            $this->storeCache($basedir, KObjectConfig::unbox($data));
+        }
+        else
+        {
+            if (!$data = require($cache)) {
+                throw new RuntimeException(sprintf('The data "%s" cannot be loaded from cache.', $cache));
+            }
+        }
+
+        return $data;
+    }
+
+    public function storeCache($file, $data)
+    {
+        if($this->_cache)
+        {
+            $path = $this->_cache_path;
+
+            if(!is_dir($path) && (false === @mkdir($path, 0755, true) && !is_dir($path))) {
+                throw new RuntimeException(sprintf('The data cache path "%s" does not exist', $path));
+            }
+
+            if(!is_writable($path)) {
+                throw new RuntimeException(sprintf('The data cache path "%s" is not writable', $path));
+            }
+
+            $hash = crc32($file.PHP_VERSION);
+            $file  = $this->_cache_path.'/data_'.$hash.'.php';
+
+            if(!is_string($data)) {
+                $data = '<?php return '.var_export($data, true).';';
+            }
+
+            if(@file_put_contents($file, $data) === false) {
+                throw new RuntimeException(sprintf('The data cannot be cached in "%s"', $file));
+            }
+
+            //Override default permissions for cache files
+            @chmod($file, 0666 & ~umask());
+
+            return $file;
+        }
+
+        return false;
+    }
+
+    public function isCached($file)
+    {
+        $result = false;
+
+        if($this->_cache)
+        {
+            $hash   = crc32($file.PHP_VERSION);
+            $cache  = $this->_cache_path.'/data_'.$hash.'.php';
+            $result = is_file($cache) ? $cache : false;
+
+            if($result && file_exists($file))
+            {
+                //Refresh cache if the file has changed or if the cache expired
+                if((filemtime($cache) < filemtime($file)) || ((time() - filemtime($cache)) > $this->_cache_time)) {
+                    $result = false;
+                }
+            }
+        }
+
         return $result;
     }
 }

--- a/code/site/components/com_pages/model/behavior/accessible.php
+++ b/code/site/components/com_pages/model/behavior/accessible.php
@@ -11,7 +11,36 @@ class ComPagesModelBehaviorAccessible extends ComPagesModelBehaviorFilterable
 {
     protected function _accept($page, $context)
     {
-        $registry = $this->getObject('page.registry');
-        return $registry->isPublished($page['path'].'/'.$page['slug']) && $registry->isAccessible($page['path'].'/'.$page['slug']);
+        if($result = $page['published'])
+        {
+            //Check groups
+            if(isset($page['access']['groups']))
+            {
+                $groups = $this->getObject('com:pages.database.table.groups')
+                    ->select($this->getObject('user')->getGroups(), KDatabase::FETCH_ARRAY_LIST);
+
+                $groups = array_map('strtolower', array_column($groups, 'title'));
+
+                if(!array_intersect($groups, $page['access']['groups'])) {
+                    $result = false;
+                }
+            }
+
+            //Check roles
+            if($result && isset($page['access']['roles']))
+            {
+                $roles = $this->getObject('com:pages.database.table.roles')
+                    ->select($this->getObject('user')->getRoles(), KDatabase::FETCH_ARRAY_LIST);
+
+                $roles = array_map('strtolower', array_column($roles, 'title'));
+
+                if(!array_intersect($roles, $page['access']['roles'])) {
+                    $result = false;
+                }
+            }
+        }
+        else $result = true;
+
+        return $result;
     }
 }

--- a/code/site/components/com_pages/model/behavior/recursable.php
+++ b/code/site/components/com_pages/model/behavior/recursable.php
@@ -57,7 +57,9 @@ class ComPagesModelBehaviorRecursable extends KModelBehaviorAbstract
 
     protected function _afterFetch(KModelContext $context)
     {
-        if (!$context->state->isUnique() && $context->state->recurse)
+        $state = $context->state;
+
+        if (!$state->isUnique() && $state->recurse && ($state->level == 0 || $state->level > 1))
         {
             $pages = clone $context->entity;
 

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -35,7 +35,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         $this->_cache_time = $config->cache_time;
 
         if(empty($config->cache_path)) {
-            $this->_cache_path = $this->getObject('com:pages.page.locator')->getBasePath().'/cache';
+            $this->_cache_path =  Koowa::getInstance()->getRootPath().'/joomlatools-pages/cache';
         } else {
             $this->_cache_path = $config->cache_path;
         }

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -14,12 +14,12 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
 
     private  $__locator = null;
 
-    private $__page  = array();
-    private $__pages = null;
-    private $__paths = array();
+    private $__pages  = array();
+    private $__data   = null;
 
     protected $_cache;
     protected $_cache_path;
+    protected $_cache_time;
 
     public function __construct(KObjectConfig $config)
     {
@@ -31,18 +31,26 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         //Set the cache
         $this->_cache = $config->cache;
 
+        //Set the cache time
+        $this->_cache_time = $config->cache_time;
+
         if(empty($config->cache_path)) {
-            $this->_cache_path = $this->getLocator()->getBasePath().'/cache';
+            $this->_cache_path = $this->getObject('com:pages.page.locator')->getBasePath().'/cache';
         } else {
             $this->_cache_path = $config->cache_path;
         }
+
+        //Load the cache and do not refresh it
+        $basedir = $this->getLocator()->getBasePath().'/pages';
+        $this->__data = $this->loadCache($basedir, false);
     }
 
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
-            'cache'      => false,
+            'cache'      => true,
             'cache_path' => '',
+            'cache_time' => 60*60*24 //1 day
         ]);
 
         parent::_initialize($config);
@@ -55,100 +63,100 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
 
     public function getPages($path = '', $mode = self::PAGES_ONLY, $depth = -1)
     {
-        $group = 'pages_'.crc32($mode.$depth);
+        $result = array();
+        $files  = $this->__data['files'];
 
-        if(!isset($this->__pages[$path.$group]))
+        if($path = trim($path, '.'))
         {
-            $directory = dirname($this->getLocator()->locate('page://pages/'. $path));
-
-            if (!$cache = $this->isCached($directory, $group))
+            $segments = array();
+            foreach(explode('/', $path) as $segment)
             {
-                $iterator = new RecursiveArrayIterator($this->_iteratePath($path));
-                $iterator = new RecursiveIteratorIterator($iterator, $mode);
-
-                //Set the max dept, -1 for full depth
-                $iterator->setMaxDepth($depth);
-
-                $result = array();
-                foreach ($iterator as $page_path => $children)
+                $segments[] = $segment;
+                if(!isset($files[implode('/', $segments)]))
                 {
-                    if(!$page = $this->getPage($page_path)) {
-                        throw new RuntimeException(sprintf('The page "%s"does not exist.', $page_path));
-                    }
-
-                    $result[$page_path] = $page->toArray();
+                    $files = false;
+                    break;
                 }
-
-                //Cache the page
-                $this->_writeCache($directory, $result, $group);
+                else $files = $files[implode('/', $segments)];
             }
-            else
-            {
-                if (!$result = require($cache)) {
-                    throw new RuntimeException(sprintf('The pages "%s" cannot be loaded from cache.', $cache));
-                }
-            }
-
-            $this->__pages[$path.$group] = $result;
         }
 
-        return $this->__pages[$path.$group];
+        if($files)
+        {
+            $iterator = new RecursiveArrayIterator($files);
+            $iterator = new RecursiveIteratorIterator($iterator, $mode);
+
+            //Set the max dept, -1 for full depth
+            $iterator->setMaxDepth($depth);
+
+            foreach ($iterator as $page => $file)
+            {
+                if(!is_string($file))
+                {
+                    if(!$file = $this->getLocator()->locate('page://pages/'. $page)) {
+                        throw new RuntimeException(sprintf('The page "%s"does not exist.', $page));
+                    }
+                }
+
+                //Get the relative file path
+                $basedir = $this->getLocator()->getBasePath().'/pages';
+                $file    = trim(str_replace($basedir, '', $file), '/');
+
+                $result[$page] = $this->__data['pages'][$file];
+            }
+        }
+
+        return $result;
     }
 
     public function getPage($path)
     {
-        $page = null;
-        $file = false;
-
         $path = ltrim($path, './');
 
-        if($path && !isset($this->__page[$path]))
+        if($path && !isset($this->__pages[$path]))
         {
-            $file = $this->getLocator()->locate('page://pages/'. $path);
-
-            if($file)
+            if($file = $this->getLocator()->locate('page://pages/'. $path))
             {
-                if(!$cache = $this->isCached($file))
+                //Get the relative file path
+                $basedir = $this->getLocator()->getBasePath().'/pages';
+                $file    = trim(str_replace($basedir, '', $file), '/');
+
+                //Load the page
+                $page = new ComPagesPage($this->__data['pages'][$file]);
+
+                //Set page default properties from collection
+                if($collection = $this->isCollection($page->path))
                 {
-                    //Load the page
-                    $page = (new ComPagesPage())->fromFile($file);
-
-                    //Set the path
-                    $page->path = trim(dirname($path), '.');
-
-                    //Set the slug
-                    $page->slug = basename($path, '.html');
-
-                    //Normalise the page data
-                    $this->_normalisePage($page);
-
-                    //Cache the page
-                    $this->_writeCache($file, $page->toArray());
-                }
-                else
-                {
-                    if(!$page = require($cache)) {
-                        throw new RuntimeException(sprintf('The page "%s" cannot be loaded from cache.', $cache));
+                    if(isset($collection['page']))
+                    {
+                        foreach($collection['page'] as $property => $value)
+                        {
+                            if(!$page->has($property)) {
+                                $page->set($property, $value);
+                            }
+                        }
                     }
-
-                    //Create a page config object
-                    $page = new ComPagesObjectConfigFrontmatter($page);
                 }
 
-                $this->__page[$path] = $page;
+                //Set the layout (if not set yet)
+                if($page->has('layout') && is_string($page->layout)) {
+                    $page->layout = array('path' => $page->layout);
+                }
+
+                $this->__pages[$path] = $page;
             }
-            else $this->__page[$path] = false;
+            else $this->__pages[$path] = false;
         }
 
-        return $this->__page[$path];
+        return $this->__pages[$path];
     }
 
     public function isPage($path)
     {
-        if(!isset($this->__page[$path])) {
+        if(!isset($this->__pages[$path])) {
            $result = (bool) $this->getLocator()->locate('page://pages/'. $path);
         } else {
-            $result = ($this->__page[$path] === false) ? false : true;
+            $result = ($this->__pages[$path] === false) ? false : true;
         }
 
         return $result;
@@ -164,99 +172,37 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         return $result;
     }
 
-    public function isAccessible($path)
+    public function buildCache()
     {
-        $result = true;
-
-        if($page = $this->getPage($path))
-        {
-            //Check groups
-            if(isset($page->access->groups))
-            {
-                $groups = $this->getObject('com:pages.database.table.groups')
-                    ->select($this->getObject('user')->getGroups(), KDatabase::FETCH_ARRAY_LIST);
-
-                $groups = array_map('strtolower', array_column($groups, 'title'));
-
-                if(!array_intersect($groups, KObjectConfig::unbox($page->access->groups))) {
-                    $result = false;
-                }
-            }
-
-            //Check roles
-            if($result && isset($page->access->roles))
-            {
-                $roles = $this->getObject('com:pages.database.table.roles')
-                    ->select($this->getObject('user')->getRoles(), KDatabase::FETCH_ARRAY_LIST);
-
-                $roles = array_map('strtolower', array_column($roles, 'title'));
-
-                if(!array_intersect($roles, KObjectConfig::unbox($page->access->roles))) {
-                    $result = false;
-                }
-            }
-        }
-
-        return $result;
-    }
-
-    public function isPublished($path)
-    {
-        $result = true;
-
-        if($page = $this->getPage($path))
-        {
-            if($page->published) {
-                $result = $page->published;
-            }
-        }
-
-        return $result;
-    }
-
-    public function isCached($file, $group = 'page')
-    {
-        $result = false;
-
         if($this->_cache)
         {
-            $hash   = crc32($file.PHP_VERSION);
-            $cache  = $this->_cache_path.'/'.$group.'_'.$hash.'.php';
-            $result = is_file($cache) ? $cache : false;
-
-            if($result && file_exists($file))
-            {
-                if(filemtime($cache) < filemtime($file)) {
-                    $result = false;
-                }
-            }
+            $basedir = $this->getLocator()->getBasePath().'/pages';
+            $this->loadCache($basedir, true);
         }
 
-        return $result;
+        return false;
     }
 
-    protected function _iteratePath($path = '')
+    public function loadCache($basedir, $refresh = true)
     {
-        $iterate = function($path) use(&$iterate)
+        if ($refresh || (!$cache = $this->isCached($basedir)))
         {
-            if(!isset($this->__paths[$path]))
+            $data = array();
+
+            //Create the data
+            $iterate = function ($dir) use (&$iterate, $basedir, &$data)
             {
-                $files = false;
+                $nodes = array();
+                $order = array();
+                $files = array();
 
                 //Only include pages
-                if($directory = $this->getLocator()->locate('page://pages/'. $path))
+                if(is_dir($dir) && !empty(glob($dir.'/index*')))
                 {
-                    $nodes = array();
-                    $order = array();
-                    $directory  = dirname($directory);
-
-                    $basepath = $this->getLocator()->getBasePath().'/pages';
-                    $basepath = ltrim(str_replace($basepath, '', $directory), '/');
-
                     //List
-                    foreach (new DirectoryIterator($directory) as $node)
+                    foreach (new DirectoryIterator($dir) as $node)
                     {
-                        if(strpos($node->getFilename(), '.order.') !== false) {
+                        if (strpos($node->getFilename(), '.order.') !== false) {
                             $order = $this->getObject('object.config.factory')->fromFile((string)$node->getFileInfo(), false);
                         } else {
                             $nodes[] = $node->getFilename();
@@ -267,76 +213,135 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
                     $nodes = array_merge(array_intersect($order, $nodes), $nodes);
 
                     //Prevent duplicates
-                    if($nodes = array_unique($nodes))
+                    if ($nodes = array_unique($nodes))
                     {
-                        $files = array();
-
-                        foreach($nodes as $node)
+                        foreach ($nodes as $node)
                         {
                             //Exclude files or folder that start with '.' or '_'
                             if (!in_array($node[0], array('.', '_')))
                             {
-                                $info     = pathinfo($node);
-                                $filepath = $basepath ? $basepath .'/'.$info['filename'] : $info['filename'];
+                                $info = pathinfo($node);
 
-                                if($info['extension'])
+                                $file = $dir . '/' . $node;
+
+                                if (strpos($node, 'index') !== false) {
+                                    $path = trim(str_replace($basedir, '', $dir), '/');
+                                } else {
+                                    $path = trim(str_replace($basedir, '', $dir . '/' . $info['filename']), '/');
+                                }
+
+                                if ($info['extension'])
                                 {
-                                    if(strpos($node, 'index') === false) {
-                                        $files[$filepath] = $filepath;
+                                    //Load the page
+                                    $page = (new ComPagesPage())->fromFile($file);
+
+                                    //Set the path
+                                    $page->path = trim(dirname($path), '.');
+
+                                    //Set the slug
+                                    $page->slug = basename($path, '.html');
+
+                                    //Set the process
+                                    if (!$page->process) {
+                                        $page->process = array();
+                                    }
+
+                                    //Set the published state (if not set yet)
+                                    if (!isset($page->published)) {
+                                        $page->published = true;
+                                    }
+
+                                    //Set the date (if not set yet)
+                                    if (!isset($page->date)) {
+                                        $page->date = filemtime($file);
+                                    }
+
+                                    //Handle dynamic data
+                                    array_walk_recursive ($page, function(&$value, $key)
+                                    {
+                                        if(is_string($value) && strpos($value, 'data://') === 0)
+                                        {
+                                            $matches = array();
+                                            preg_match('#data\:\/\/([^\[]+)(?:\[(.*)\])*#si', $value, $matches);
+
+                                            if(!empty($matches[0]))
+                                            {
+                                                $data = $this->getObject('data.registry')->getData($matches[1]);
+
+                                                if($data && !empty($matches[2])) {
+                                                    $data = $data->get($matches[2]);
+                                                }
+
+                                                $value = $data;
+                                            }
+                                        }
+                                    });
+
+                                    //Store the relative file path
+                                    $file = trim(str_replace($basedir, '', $file), '/');
+
+                                    $data[$file] = $page->toArray();
+
+                                    if (strpos($node, 'index') === false) {
+                                        $files[$path] = $file;
                                     }
                                 }
                                 else
                                 {
-                                    if(false !== $result = $iterate($filepath))
-                                    {
-                                        if($result) {
-                                            $files[$filepath] = $result;
-                                        } else {
-                                            $files[$filepath] = $filepath;
-                                        }
+                                    if($result = $iterate($file)) {
+                                        $files[$path] = $result;
                                     }
                                 }
                             }
                         }
                     }
+
+                    return $files;
                 }
+                else return false;
+            };
 
-                $this->__paths[$path] = $files;
+            Closure::bind($iterate, $this, get_class());
+
+            $result['files'] = $iterate($basedir);
+            $result['pages'] = $data;
+
+            $this->storeCache($basedir, $result);
+        }
+        else
+        {
+            if (!$result = require($cache)) {
+                throw new RuntimeException(sprintf('The page registry "%s" cannot be loaded from cache.', $cache));
             }
-            else $files = $this->__paths[$path];
+        }
 
-            return $files;
-        };
+        return $result;
 
-        Closure::bind($iterate, $this, get_class());
-        $files = $iterate($path);
-
-        return $files;
     }
 
-    protected function _writeCache($file, $data, $group = 'page')
+    public function storeCache($file, $data)
     {
         if($this->_cache)
         {
             $path = $this->_cache_path;
 
             if(!is_dir($path) && (false === @mkdir($path, 0755, true) && !is_dir($path))) {
-                throw new RuntimeException(sprintf('The page cache path "%s" does not exist', $path));
+                throw new RuntimeException(sprintf('The page registry cache path "%s" does not exist', $path));
             }
 
             if(!is_writable($path)) {
-                throw new RuntimeException(sprintf('The page cache path "%s" is not writable', $path));
+                throw new RuntimeException(sprintf('The page registry cache path "%s" is not writable', $path));
             }
 
             $hash = crc32($file.PHP_VERSION);
-            $file  = $this->_cache_path.'/'.$group.'_'.$hash.'.php';
+            $file  = $this->_cache_path.'/page_'.$hash.'.php';
 
             if(!is_string($data)) {
                 $data = '<?php return '.var_export($data, true).';';
             }
 
             if(@file_put_contents($file, $data) === false) {
-                throw new RuntimeException(sprintf('The page cannot be cached in "%s"', $file));
+                throw new RuntimeException(sprintf('The page registry cannot be cached in "%s"', $file));
             }
 
             //Override default permissions for cache files
@@ -348,61 +353,24 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         return false;
     }
 
-    protected function _normalisePage($page)
+    public function isCached($file)
     {
-        //Set the process
-        if(!$page->process) {
-            $page->process = array();
-        }
+        $result = false;
 
-        //Set the published state (if not set yet)
-        if (!isset($page->published)) {
-            $page->published = true;
-        }
-
-        //Set the date (if not set yet)
-        if (!isset($page->date)) {
-            $page->date = filemtime($page->getFilename());
-        }
-
-        //Set page default properties from collection
-        if($collection = $this->getObject('page.registry')->isCollection($page->path))
+        if($this->_cache)
         {
-            if(isset($collection['page']))
+            $hash   = crc32($file.PHP_VERSION);
+            $cache  = $this->_cache_path.'/page_'.$hash.'.php';
+            $result = is_file($cache) ? $cache : false;
+
+            if($result && file_exists($file))
             {
-                foreach($collection['page'] as $property => $value)
-                {
-                    if(!$page->has($property)) {
-                        $page->set($property, $value);
-                    }
+                if((filemtime($cache) < filemtime($file)) || ((time() - filemtime($cache)) > $this->_cache_time)) {
+                    $result = false;
                 }
             }
         }
 
-        //Set the layout (if not set yet)
-        if($page->has('layout') && is_string($page->layout)) {
-            $page->layout = array('path' => $page->layout);
-        }
-
-        //Handle dynamic data
-        array_walk_recursive ($page, function(&$value, $key)
-        {
-            if(is_string($value) && strpos($value, 'data://') === 0)
-            {
-                $matches = array();
-                preg_match('#data\:\/\/([^\[]+)(?:\[(.*)\])*#si', $value, $matches);
-
-                if(!empty($matches[0]))
-                {
-                    $data = $this->getObject('data.registry')->getData($matches[1]);
-
-                    if($data && !empty($matches[2])) {
-                        $data = $data->get($matches[2]);
-                    }
-
-                    $value = $data;
-                }
-            }
-        });
+        return $result;
     }
 }

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -53,9 +53,16 @@ return array(
             }
         ],
         'com://site/pages.dispatcher.behavior.cacheable' => [
-            'cache'         => $config['cache'] ?? false,
-            'cache_time'    => $config['cache_time'] ?? 0,
-            'cache_private' => $config['cache_private'] ?? false,
+            'cache'         => $config['http_cache'] ?? false,
+            'cache_time'    => $config['http_cache_time'] ?? 7200, //2h
+        ],
+        'com://site/pages.page.registry' => [
+            'cache'         => $config['page_cache'] ?? false,
+            'cache_time'    => $config['page_cache_time'] ?? 60*60*24, //1d
+        ],
+        'com://site/pages.data.registry' => [
+            'cache'         => $config['data_cache'] ?? false,
+            'cache_time'    => $config['data_cache_time'] ?? 60*60*24, //1d
         ],
 
     ]


### PR DESCRIPTION
This PR refactors the page and data cache. 

### Page registry cache

The page registry cache is stored in a single file, prefixed with 'page_'. The file contains the files structure and the file metadata as a php array. The actual content of the file is not cached. 

- Added an additional ComPagesPageRegistry::buildCache() method to programmatically build the cache, for example during a deploy.

- Added a ComPagesPageRegistry::cache_time config option to allow defining the cache expiration time in seconds, default 60*60*24 or 1 day.

### Data cache

The data registry cache stores a file per root data folder, prefixed with 'data_'. The file contains the data as a php array. 

- Added an additional ComPagesDataRegistry::buildCache() method to programmatically build the cache, for example during a deploy.

- Added a ComPagesDataRegistry::cache_time config option to allow defining the cache expiration time in seconds, default 60*60*24 or 1 day.

### Configuration

Added following config options:

- page_cache: default enabled if debug disabled
- page_cache_time: 60*60*24 //1d

- data_cache: default enabled if debug disabled
- data_cache_time: 60*60*24, //1d

Renamed cache and cache_time options to:

- http_cache: false
- http_cache_time: 7200

### Notes:

- This PR also includes a change in the way data works. If a data file has the same name as the folder it's part of, the file will not result in an additional level in the data collection. If the file has a different name the key of the level will be the name of the file

- This issue also adds an additional ComPagesDataObject::flatten() method which is capable of flatting the first level of a data object.