### PR TITLE
Allow keeping track of data folder when flattening 

### DIFF
--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -25,7 +25,7 @@ class ComPagesDataObject extends KObjectConfig
         return new self($data);
     }
 
-    public function flatten($folder = false)
+    public function flatten($key_as_property = null)
     {
         $data = array();
 
@@ -33,12 +33,11 @@ class ComPagesDataObject extends KObjectConfig
         {
             if(is_array($values))
             {
-                if ($folder && !is_numeric($key))
+                if (is_string($key_as_property) && !is_numeric($key))
                 {
                     // Keep current key as a property of the data object
-
                     foreach ($values as &$value) {
-                        $value['folder'] = $key;
+                        $value[$key_as_property] = $key;
                     }
                 }
 

--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -25,7 +25,7 @@ class ComPagesDataObject extends KObjectConfig
         return new self($data);
     }
 
-    public function flatten($property = null)
+    public function flatten($folder = false)
     {
         $data = array();
 
@@ -33,12 +33,12 @@ class ComPagesDataObject extends KObjectConfig
         {
             if(is_array($values))
             {
-                if (isset($property) && !is_numeric($key))
+                if ($folder && !is_numeric($key))
                 {
                     // Keep current key as a property of the data object
 
                     foreach ($values as &$value) {
-                        $value[$property] = $key;
+                        $value['folder'] = $key;
                     }
                 }
 

--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -25,17 +25,26 @@ class ComPagesDataObject extends KObjectConfig
         return new self($data);
     }
 
-    public function flatten()
+    public function flatten($property = null)
     {
         $data = array();
 
         foreach( $this->toArray() as $key => $values)
         {
-            if(is_array($values)) {
+            if(is_array($values))
+            {
+                if (isset($property) && !is_numeric($key))
+                {
+                    // Keep current key as a property of the data object
+
+                    foreach ($values as &$value) {
+                        $value[$property] = $key;
+                    }
+                }
+
                 $data = array_merge($data, $values);
-            } else {
-                $data[] = $values;
             }
+            else $data[] = $values;
         }
 
         return new self($data);


### PR DESCRIPTION
fixes #51

### Use case / Test instructions

On joomlatools site this would be used on partials/global/testimonial.html.php

$testimonials = data('testimonials')->flatten();

would be replaced by:

$testimonials = data('testimonials')->flatten(true);

so that we have access to the testimonial extension through $testimonial->folder. This would allow us to do this on the global extensions page: https://dsh.re/44f7a (see docman and logman labels below rating)


