### PR TITLE
Content plugins page filter

### DIFF
--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -33,7 +33,6 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
                 'metadata'    => [],
                 'process'     => [
                     'filters' => array(),
-                    'plugins' => true
                 ],
                 'layout'      => array(),
                 'colllection' => false,

--- a/code/site/components/com_pages/template/filter/plugins.php
+++ b/code/site/components/com_pages/template/filter/plugins.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesTemplateFilterPlugins extends KTemplateFilterAbstract
+{
+    public function filter(&$text)
+    {
+        $matches = array();
+        if(preg_match_all('#<ktml:plugins>(.*)<\/ktml:plugins>#siU', $text, $matches))
+        {
+            $page = $this->getTemplate()->page();
+
+            foreach($matches[0] as $key => $match)
+            {
+                $content = new stdClass;
+                $content->text = $matches[1][$key];
+
+                $params = (object) $page->getProperties();
+
+                //Trigger onContentBeforeDisplay
+                $results = array();
+                $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
+                    'name'         => 'onContentBeforeDisplay',
+                    'import_group' => 'content',
+                    'attributes'   => array('com_pages.item', &$content, &$params)
+                ));
+
+                //Trigger onContentPrepare
+                $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
+                    'name'         => 'onContentPrepare',
+                    'import_group' => 'content',
+                    'attributes'   => array('com_pages.item', &$content, &$params)
+                ));
+
+                //Trigger onContentAfterDisplay
+                $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
+                    'name'         => 'onContentAfterDisplay',
+                    'import_group' => 'content',
+                    'attributes'   => array('com_pages.item', &$content, &$params)
+                ));
+
+                $result = trim(implode("\n", $results));
+
+                $text = str_replace($match, $result, $text);
+            }
+        }
+    }
+}

--- a/code/site/components/com_pages/view/page/html.php
+++ b/code/site/components/com_pages/view/page/html.php
@@ -9,47 +9,5 @@
 
 class ComPagesViewPageHtml extends ComPagesViewHtml
 {
-    public function __construct(KObjectConfig $config)
-    {
-        parent::__construct($config);
 
-        $this->addCommandCallback('after.render' , '_processPlugins');
-    }
-
-    protected function _processPlugins(KViewContextInterface $context)
-    {
-        $page = $this->getModel()->getPage();
-
-        if($page->process->plugins)
-        {
-            $content = new stdClass;
-            $content->text = $context->result;
-
-            $params = (object)$page->getProperties();
-
-            //Trigger onContentBeforeDisplay
-            $results = array();
-            $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
-                'name'         => 'onContentBeforeDisplay',
-                'import_group' => 'content',
-                'attributes'   => array('com_pages.page', &$content, &$params)
-            ));
-
-            //Trigger onContentPrepare
-            $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
-                'name'         => 'onContentPrepare',
-                'import_group' => 'content',
-                'attributes'   => array('com_pages.page', &$content, &$params)
-            ));
-
-            //Trigger onContentAfterDisplay
-            $results[] = $this->getTemplate()->createHelper('event')->trigger(array(
-                'name'         => 'onContentAfterDisplay',
-                'import_group' => 'content',
-                'attributes'   => array('com_pages.page', &$content, &$params)
-            ));
-
-            $context->result = trim(implode("\n", $results));;
-        }
-    }
 }


### PR DESCRIPTION
To pass the content to the content plugins for processing wrap it in a `<ktml:plugins>[...]</ktml:plugins>` block. Example:

```html
<ktml:plugins>
Content goes here
</ktml:plugins> 
```
The content is passed to the following plugin events :

- onContentBeforeDisplay
- onContentPrepare
- onConntentAfterDisplay

The result is returned and the `<ktml:plugins></ktml:plugins>` block replaced with the result.

Plugin processing is not enabled by default it needs to be enabled by adding the `plugins` filter to the `process:filters` list in the page frontmatter.







