### PR TITLE
Remote collections

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -21,8 +21,6 @@ class ComPagesControllerAbstract extends KControllerModel
 
     public function getFormats()
     {
-        $formats = parent::getFormats();
-
         if($this->getObject('dispatcher')->getRouter()->resolve()) {
             $formats = array($this->getRequest()->getFormat());
         }  else {

--- a/code/site/components/com_pages/data/client.php
+++ b/code/site/components/com_pages/data/client.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesDataClient extends KObject implements KObjectSingleton
+{
+    protected $_cache;
+    protected $_cache_path;
+    protected $_cache_time;
+
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        //Set the cache
+        $this->_cache = $config->cache;
+
+        //Set the cache time
+        $this->_cache_time = $config->cache_time;
+
+        if(empty($config->cache_path)) {
+            $this->_cache_path = Koowa::getInstance()->getRootPath().'/joomlatools-pages/cache';
+        } else {
+            $this->_cache_path = $config->cache_path;
+        }
+    }
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'cache'      => JDEBUG ? false : true,
+            'cache_path' => '',
+            'cache_time' => 60*60*24 //1 day
+        ]);
+
+        parent::_initialize($config);
+    }
+
+    public function fromUrl($url, $object = true)
+    {
+        $config = null;
+
+        if(!$cache = $this->isCached($url))
+        {
+            if(!ini_get('allow_url_fopen')) {
+                throw new \RuntimeException('Cannot use a stream transport when "allow_url_fopen" is disabled.');
+            }
+
+            $version = $this->getObject('com:pages.version');
+            $context = stream_context_create(array('http' => array(
+                'user_agent' => 'Joomlatools/Pages/'.$version,
+                'protocol_version' => 1.1,
+                'header'           => [
+                    'Connection: close',
+                ],
+            )));
+
+            if($headers = get_headers($url, true, $context))
+            {
+                $status = explode(' ', $headers[0], 3);
+                $response = $this->getObject('http.response', [
+                    'status_code'    => $status[1],
+                    'status_message' => $status[2],
+                    'headers'        => $headers
+                ]);
+
+                $factory = $this->getObject('object.config.factory');
+                $format  = $response->getFormat();
+
+                //Request failed
+                if(!$response->isSuccess())
+                {
+                    throw new RuntimeException(
+                        sprintf('Cannot get data from url, error: "%s %s"', $response->getStatusCode(), $response->getStatusMessage()
+                    ));
+                }
+
+                if($content = file_get_contents($url, false, $context)) {
+                    $config = $factory->createFormat($format)->fromString($content, $object);
+                }
+            }
+            else
+            {
+                if($error = error_get_last()) {
+                    throw new RuntimeException(sprintf('Cannot get data from url, error: "%s"', trim($error['message'])));
+                } else {
+                    throw new RuntimeException(sprintf('Cannot get data from url: "%s"', $url));
+                }
+            }
+
+            $this->storeCache($url, KObjectConfig::unbox($config));
+        }
+        else
+        {
+            if (!$config = require($cache)) {
+                throw new RuntimeException(sprintf('The data "%s" cannot be loaded from cache.', $cache));
+            }
+        }
+
+        return $config;
+    }
+
+    public function storeCache($url, $data)
+    {
+        if($this->_cache)
+        {
+            $path = $this->_cache_path;
+
+            if(!is_dir($path) && (false === @mkdir($path, 0755, true) && !is_dir($path))) {
+                throw new RuntimeException(sprintf('The url cache path "%s" does not exist', $path));
+            }
+
+            if(!is_writable($path)) {
+                throw new RuntimeException(sprintf('The url cache path "%s" is not writable', $path));
+            }
+
+            if(!is_string($data))
+            {
+                //Do not cache userinfo
+                $location = KHttpUrl::fromString($url)->toString(KHttpUrl::FULL ^ KHttpUrl::USERINFO);
+
+                $result = '<?php /*//url:'.$location.'*/'."\n";
+                $result .= 'return '.var_export($data, true).';';
+            }
+
+            $hash = crc32($url.PHP_VERSION);
+            $file  = $this->_cache_path.'/remote_'.$hash.'.php';
+
+            if(@file_put_contents($file, $result) === false) {
+                throw new RuntimeException(sprintf('The url cannot be cached in "%s"', $file));
+            }
+
+            //Override default permissions for cache files
+            @chmod($file, 0666 & ~umask());
+
+            return $file;
+        }
+
+        return false;
+    }
+
+    public function isCached($url)
+    {
+        $result = false;
+
+        if($this->_cache)
+        {
+            $hash   = crc32($url.PHP_VERSION);
+            $cache  = $this->_cache_path.'/remote_'.$hash.'.php';
+            $result = is_file($cache) ? $cache : false;
+
+            if($result)
+            {
+                //Refresh cache if it expired
+                if((time() - filemtime($result)) > $this->_cache_time) {
+                    $result = false;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+}

--- a/code/site/components/com_pages/data/client.php
+++ b/code/site/components/com_pages/data/client.php
@@ -41,7 +41,7 @@ class ComPagesDataClient extends KObject implements KObjectSingleton
         parent::_initialize($config);
     }
 
-    public function fromUrl($url, $object = true)
+    public function fromUrl($url, $object = true, KHttpRequest $request = null)
     {
         $config = null;
 
@@ -51,13 +51,15 @@ class ComPagesDataClient extends KObject implements KObjectSingleton
                 throw new \RuntimeException('Cannot use a stream transport when "allow_url_fopen" is disabled.');
             }
 
+            if(!$request) {
+                $request = $this->getObject('http.request');
+            }
+
             $version = $this->getObject('com:pages.version');
             $context = stream_context_create(array('http' => array(
                 'user_agent' => 'Joomlatools/Pages/'.$version,
                 'protocol_version' => 1.1,
-                'header'           => [
-                    'Connection: close',
-                ],
+                'header'           => (string) $request->getHeaders()->set('Connection', 'close')
             )));
 
             if($headers = get_headers($url, true, $context))

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -96,7 +96,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
                 $result = $this->__fromFile($file);
             }
         }
-        else $result = $this->__fromUrl($path, $format);
+        else $result =  $this->getObject('com:pages.data.client')->fromUrl($path, false);
 
         return $result;
     }
@@ -108,7 +108,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
 
         $url = trim(fgets(fopen($file, 'r')));
         if(strpos($url, '://') === 0) {
-            $result = $this->__fromUrl($url, pathinfo($file, PATHINFO_EXTENSION));
+            $result =  $this->getObject('com:pages.data.client')->fromUrl($url, false);
         } else {
             $result = $this->getObject('object.config.factory')->fromFile($file, false);
         }
@@ -166,38 +166,6 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         }
 
         return $data;
-    }
-
-    private function __fromUrl($url, $format = '')
-    {
-        if(!ini_get('allow_url_fopen')) {
-            throw new RuntimeException(sprintf('Cannot open url: "%s".', $url));
-        }
-
-        if(empty($format))
-        {
-            if(!$format = pathinfo(parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION)) {
-                throw new InvalidArgumentException(sprintf('Cannot determine data type of "%s".', $url));
-            }
-        }
-
-        //Set the user agents
-        $version = $this->getObject('com:pages.version');
-        $context = stream_context_create(array('http' => array(
-            'user_agent' => 'Joomlatools/Pages/'.$version,
-        )));
-
-        if(!$content = file_get_contents($url, false, $context))
-        {
-            if($error = error_get_last()) {
-                throw new RuntimeException(sprintf('Cannot get content from url error: "%s"', trim($error['message'])));
-            } else {
-                throw new RuntimeException(sprintf('Cannot get content from url: "%s"', $url));
-            }
-        }
-
-        $result = $this->getObject('object.config.factory')->fromString($format, $content, false);
-        return $result;
     }
 
     public function buildCache()

--- a/code/site/components/com_pages/model/collection.php
+++ b/code/site/components/com_pages/model/collection.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-abstract class ComPagesModelAbstract extends KModelAbstract
+abstract class ComPagesModelCollection extends KModelAbstract
 {
     protected $_data;
 

--- a/code/site/components/com_pages/model/factory.php
+++ b/code/site/components/com_pages/model/factory.php
@@ -30,18 +30,10 @@ class ComPagesModelFactory extends KObject implements KObjectSingleton
         if($collection = $this->getObject('page.registry')->getCollection($source))
         {
             //Create the model
-            $source = KObjectConfig::unbox($collection->source);
+            $source = KHttpUrl::fromString($collection->source);
 
-            if(is_array($source))
-            {
-                $model  = key($source);
-                $config = current($source);
-            }
-            else
-            {
-                $model  = $source;
-                $config = array();
-            }
+            $model  = $source->toString(KHttpUrl::BASE);
+            $config = $source->query;
 
             if(is_string($model) && strpos($model, '.') === false )
             {
@@ -49,7 +41,6 @@ class ComPagesModelFactory extends KObject implements KObjectSingleton
                 $identifier['name'] = $model;
             }
             else $identifier = $model;
-
 
             $model = $this->getObject($identifier, $config);
 

--- a/code/site/components/com_pages/model/factory.php
+++ b/code/site/components/com_pages/model/factory.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesModelFactory extends KObject implements KObjectSingleton
+{
+    public function createPage($path)
+    {
+        $entity = false;
+
+        if ($page = $this->getObject('page.registry')->getPage($path))
+        {
+            $entity = $this->getObject('com:pages.model.entity.page',
+                array('data'  => $page->toArray())
+            );
+        }
+
+        return $entity;
+    }
+
+    public function createCollection($source, $state = array())
+    {
+        $model = false;
+
+        if($collection = $this->getObject('page.registry')->getCollection($source))
+        {
+            //Create the model
+            $source = KObjectConfig::unbox($collection->source);
+
+            if(is_array($source))
+            {
+                $model  = key($source);
+                $config = current($source);
+            }
+            else
+            {
+                $model  = $source;
+                $config = array();
+            }
+
+            if(is_string($model) && strpos($model, '.') === false )
+            {
+                $identifier = $this->getIdentifier()->toArray();
+                $identifier['name'] = $model;
+            }
+            else $identifier = $model;
+
+
+            $model = $this->getObject($identifier, $config);
+
+            if(!$model instanceof KModelInterface)
+            {
+                throw new UnexpectedValueException(
+                    'Collection: '.get_class($model).' does not implement KModelInterface'
+                );
+            }
+
+            //Set the state
+            if(isset($collection->state)) {
+                $state  = $collection->state->merge($state);
+            }
+
+            $model->setState(KObjectConfig::unbox($state));
+        }
+
+        return $model;
+    }
+}

--- a/code/site/components/com_pages/model/page.php
+++ b/code/site/components/com_pages/model/page.php
@@ -24,60 +24,27 @@ class ComPagesModelPage extends KModelAbstract
         return $this;
     }
 
-    public function getPage($path = '')
+    public function getPage()
     {
-        $result = null;
-
-        if ($path)
+        if($this->__page && !$this->__page instanceof ComPagesModelEntityPage)
         {
-            if ($page = $this->getObject('page.registry')->getPage($path))
-            {
-                $result = $this->getObject('com:pages.model.entity.page',
-                    array('data'  => $page->toArray())
-                );
-            }
-        }
-        else
-        {
-            if($this->__page && !$this->__page instanceof ComPagesModelEntityPage)
-            {
-                $this->__page = $this->getObject('com:pages.model.entity.page',
-                    array('data'  =>  $this->__page->toArray())
-                );
-            }
-
-            $result = $this->__page;
+            $this->__page = $this->getObject('com:pages.model.entity.page',
+                array('data'  =>  $this->__page->toArray())
+            );
         }
 
-        return $result;
+        return  $this->__page;
     }
 
-    public function getCollection($source = '', $state = array())
+    public function getCollection()
     {
-        $collection = false;
-
-        if(!$source)
+        if(is_null($this->__collection) && $page = $this->getPage())
         {
-            if($page = $this->getPage())
-            {
-                if(is_null($this->__collection)) {
-                    $this->__collection = $this->_createCollection($this->getPage()->route);
-                }
-
-                $collection = $this->__collection;
-            }
-        }
-        else
-        {
-            if(!$collection = $this->_createCollection($source, $state))
-            {
-                throw new UnexpectedValueException(
-                    'Collection: '.$source.' does not exist'
-                );
-            }
+            $this->__collection = $this->getObject('com:pages.model.factory')
+                    ->createCollection($this->getPage()->route);
         }
 
-        return $collection;
+        return  $this->__collection;
     }
 
     public function setState(array $values)
@@ -131,32 +98,5 @@ class ComPagesModelPage extends KModelAbstract
         } else {
             parent::_actionReset($context);
         }
-    }
-
-    protected function _createCollection($source, $state = array())
-    {
-        $model = false;
-
-        if($collection = $this->getObject('page.registry')->getCollection($source))
-        {
-            //Create the model
-            $model = $this->getObject($collection->source);
-
-            if(!$model instanceof KModelInterface)
-            {
-                throw new UnexpectedValueException(
-                    'Collection: '.get_class($model).' does not implement KModelInterface'
-                );
-            }
-
-            //Set the state
-            if(isset($collection->state)) {
-                $state  = $collection->state->merge($state);
-            }
-
-            $model->setState(KObjectConfig::unbox($state));
-        }
-
-        return $model;
     }
 }

--- a/code/site/components/com_pages/model/pages.php
+++ b/code/site/components/com_pages/model/pages.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesModelPages extends ComPagesModelAbstract
+class ComPagesModelPages extends ComPagesModelCollection
 {
     public function __construct(KObjectConfig $config)
     {

--- a/code/site/components/com_pages/model/remote.php
+++ b/code/site/components/com_pages/model/remote.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesModelRemote extends ComPagesModelCollection
+{
+    protected $_url;
+
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        $this->_url = $config->url;
+    }
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'url'  => '',
+        ]);
+
+        parent::_initialize($config);
+    }
+
+    public function getUrl(array $variables)
+    {
+        return KHttpUrl::fromTemplate($this->_url, $variables);
+    }
+
+    public function getData()
+   {
+       if(!isset($this->_data))
+       {
+           $state = $this->getState();
+
+           if($url = $this->getUrl($state->getValues())) {
+               $this->_data = $this->getObject('com:pages.data.client')->fromUrl($url, false);
+           }
+       }
+
+       return (array) $this->_data;
+   }
+}

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -21,6 +21,7 @@ return array(
         'data.registry' => 'com:pages.data.registry',
         'com:pages.version'     => 'com://admin/pages.version',
         'com:pages.data.object' => 'com://site/pages.data.object',
+        'com:pages.data.client' => 'com://site/pages.data.client',
     ],
 
     'identifiers' => [
@@ -74,6 +75,11 @@ return array(
         ],
         'com://site/pages.dispatcher.router.resolver.redirect' => [
             'routes'  => isset($config['redirects']) ? array_flip($config['redirects']) : false,
+        ],
+        'com://site/pages.data.client' => [
+            'cache'      => $config['remote_cache'] ?? (JDEBUG ? false : true),
+            'cache_time' => $config['remote_cache_time'] ?? 60*60*24, //1d
+            'cache_path' => $config['remote_cache_path'] ?? null
         ],
     ]
 );

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -105,13 +105,19 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
 
     public function getPage($path = null)
     {
-        return $this->getModel()->getPage($path);
+        if($path) {
+            $result = $this->getObject('com:pages.model.factory')->createPage($path);
+        } else {
+            $result = $this->getModel()->getPage();
+        }
+
+        return $result;
     }
 
     public function getCollection($source = '', $state = array())
     {
         if($source) {
-            $result = $this->getModel()->getCollection($source, $state)->fetch();
+            $result = $this->getObject('com:pages.model.factory')->createCollection($source, $state)->fetch();
         } else {
             $result = $this->getModel()->fetch();
         }

--- a/code/site/components/com_pages/view/json.php
+++ b/code/site/components/com_pages/view/json.php
@@ -20,13 +20,19 @@ class ComPagesViewJson extends KViewJson
 
     public function getPage($path = null)
     {
-        return $this->getModel()->getPage($path);
+        if($path) {
+            $result = $this->getObject('com:pages.model.factory')->createPage($path);
+        } else {
+            $result = $this->getModel()->getPage();
+        }
+
+        return $result;
     }
 
     public function getCollection($source = '', $state = array())
     {
         if($source) {
-            $result = $this->getModel()->getCollection($source, $state)->fetch();
+            $result = $this->getObject('com:pages.model.factory')->createCollection($source, $state)->fetch();
         } else {
             $result = $this->getModel()->fetch();
         }
@@ -38,29 +44,6 @@ class ComPagesViewJson extends KViewJson
     {
         if(!is_array($query)) {
             $query = array();
-        }
-
-        if($page instanceof ComPagesModelEntityPage) {
-            $route = $page->route;
-        } else {
-            $route = $page;
-        }
-
-        //Add the model state only for routes to the same page
-        if($page == $this->getPage()->route)
-        {
-            if($collection = $this->getPage($page)->collection)
-            {
-                $states = array();
-                foreach ($this->getModel()->getState() as $name => $state)
-                {
-                    if ($state->default != $state->value && !$state->internal) {
-                        $states[$name] = $state->value;
-                    }
-                }
-
-                $query = array_merge($states, $query);
-            }
         }
 
         if($route = $this->getObject('dispatcher')->getRouter()->generate($page, $query)) {

--- a/code/site/components/com_pages/view/xml.php
+++ b/code/site/components/com_pages/view/xml.php
@@ -107,13 +107,19 @@ class ComPagesViewXml extends KViewTemplate
 
     public function getPage($path = null)
     {
-        return $this->getModel()->getPage($path);
+        if($path) {
+            $result = $this->getObject('com:pages.model.factory')->createPage($path);
+        } else {
+            $result = $this->getModel()->getPage();
+        }
+
+        return $result;
     }
 
     public function getCollection($source = '', $state = array())
     {
         if($source) {
-            $result = $this->getModel()->getCollection($source, $state)->fetch();
+            $result = $this->getObject('com:pages.model.factory')->getCollection($source, $state)->fetch();
         } else {
             $result = $this->getModel()->fetch();
         }
@@ -130,29 +136,6 @@ class ComPagesViewXml extends KViewTemplate
     {
         if(empty($page)) {
             $page = $this->getPage();
-        }
-
-        if($page instanceof ComPagesModelEntityPage) {
-            $route = $page->route;
-        } else {
-            $route = $page;
-        }
-
-        //Add the model state only for routes to the same page
-        if($page == $this->getPage()->route)
-        {
-            if($collection = $this->getPage($page)->collection)
-            {
-                $states = array();
-                foreach ($this->getModel()->getState() as $name => $state)
-                {
-                    if ($state->default != $state->value && !$state->internal) {
-                        $states[$name] = $state->value;
-                    }
-                }
-
-                $query = array_merge($states, $query);
-            }
         }
 
         if($route = $this->getObject('dispatcher')->getRouter()->generate($page, $query)) {


### PR DESCRIPTION
## Remote collections

This PR implements support for remote for collections. A collection can now easily be retrieved from any URL. The implementation offers support for URI templates to make creating dynamic URL's easy.

### 1. Defining remote collections

A remote collection can be defined easily by specifying the url where the collection should be retrieved from. For example:

```yaml
collection:
   source: remote?url=http://www.example.com
```

`remote`is a shortcut for `com:pages.model.remote`

The `url`parameter defines the location for the remote collection and can be templated using the [template URI's](https://tools.ietf.org/html/rfc6570) standard. When  a template uri is used the model state will be used to expand the template url.  For example:

```yaml
collection:
   source: remote?url=http://example.com{+path}{/segments*}{?query,data*}
   state:
     path: /foo/bar
     segments: ['one', 'two']
     query:  test
     data: 
        more: value
```

The resulting URL would become http://example.com/foo/bar/one/two?query=test&more=value.

For more info see on using template uri's for remote collections please see: https://github.com/joomlatools/joomlatools-framework/pull/262

### 2. Custom remote collections

The ability to create custom collections is provided through extending the `ComPagesModelRemote` class. See: https://github.com/joomlatools/joomlatools-pages/blob/44fd7e712ec4360617f08ced57f7dfefc3c0d710/code/site/components/com_pages/model/remote.php

### Remote data cache

The data client cache stores a file per url prefixed with 'remote_'. The file contains the data as a php array. 

A `ComPagesDataClient::cache_time` config option to allow defining the cache expiration time in seconds, default `60*60*24` or 1 day.

A `ComPagesDataClient::cache_path` config option to allow the cach location, defaults to /joomlatools-pages/cache

### Remote data cache configuration

Added following config options:

remote_cache: `JDEBUG ? false : true`
remote_cache_time: `60*60*24, //1d`
remote_cache_path: /joomlatools-pages/cache

### Notes

- The `ComPagesModelAbstract` has been renamed to `ComPagesModelCollection`. To implement base custom collections you need to specialise this class.

- The creation of a collection and a page entity has been moved from `ComPagesModelPage` to `ComPagesModelFactory`
