### PR TITLE
Add http_cache_time_proxy setting

### DIFF
--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -26,7 +26,8 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
         $config->append(array(
             'cache'      => false,
             'cache_path' => '',
-            'cache_time' => 7200, //2h
+            'cache_time'        => 60*15,   //15min
+            'cache_time_shared' => 60*60*2, //2h
         ));
 
         parent::_initialize($config);
@@ -71,7 +72,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
                 if ($cache !== false)
                 {
                     if(is_int($cache)) {
-                        $context->getResponse()->setMaxAge($cache);
+                        $context->getResponse()->setMaxAge($this->getConfig()->cache_time, $cache);
                     }
                 }
                 else $this->getConfig()->cache = false;
@@ -91,7 +92,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
             if($content = $response->getContent())
             {
                 $data = array(
-                    'headers' => $this->getResponse()->getHeaders(),
+                    'headers' => $response->getHeaders()->toArray(),
                     'content' => $content,
                 );
 

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -69,9 +69,10 @@ return array(
             }
         ],
         'com://site/pages.dispatcher.behavior.cacheable' => [
-            'cache'      => $config['http_cache'] ?? false,
-            'cache_time' => $config['http_cache_time'] ?? 7200, //2h
-            'cache_path' => $config['http_cache_path'] ?? null
+            'cache'             => $config['http_cache'] ?? false,
+            'cache_path'        => $config['http_cache_path'] ?? null,
+            'cache_time'        => $config['http_cache_time']       ?? 60*15,  //15min
+            'cache_time_shared' => $config['http_cache_time_proxy'] ?? 60*60*2, //2h
         ],
         'com://site/pages.dispatcher.router.resolver.redirect' => [
             'routes'  => isset($config['redirects']) ? array_flip($config['redirects']) : false,


### PR DESCRIPTION
This PR adds a new http_cache_time_proxy setting to allows defining the s-maxage cache directive. The default cache time is set to 15min and the shared proxy cache time is set to 2h.

See also: https://github.com/joomlatools/joomlatools-framework/pull/266