### PR TITLE
Filesystem collections

### DIFF
--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -52,7 +52,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         return $this->__locator;
     }
 
-    public function getData($path)
+    public function getData($path, $object = true)
     {
         $result = array();
         if(!isset($this->__data[$path]))
@@ -74,11 +74,18 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
             }
 
             //Create the data object
-            $class = $this->getObject('manager')->getClass('com:pages.data.object');
-            $this->__data[$path] = new $class($data);
+            $this->__data[$path] = $data;
         }
 
-        return $this->__data[$path];
+        if($object)
+        {
+            $class = $this->getObject('manager')->getClass('com:pages.data.object');
+            $result = new $class($this->__data[$path]);
+        }
+        else $result = $this->__data[$path];
+
+
+        return $result;
     }
 
     private function __fromPath($path)
@@ -86,7 +93,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         if(!parse_url($path, PHP_URL_SCHEME) == 'http')
         {
             //Locate the data file
-            if (!$path = $this->getLocator()->locate('data://'.$path)) {
+            if (!$path = $this->getLocator()->locate($path)) {
                 throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
             }
 

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -85,12 +85,9 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
     {
         if(!parse_url($path, PHP_URL_SCHEME) == 'http')
         {
-            if(!file_exists($path))
-            {
-                //Locate the data file
-                if (!$path = $this->getLocator()->locate($path)) {
-                    throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
-                }
+            //Locate the data file
+            if (!$path = $this->getLocator()->locate('data://'.$path)) {
+                throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
             }
 
             if(is_dir($path)) {

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -93,14 +93,14 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         if(!parse_url($path, PHP_URL_SCHEME) == 'http')
         {
             //Locate the data file
-            if (!$path = $this->getLocator()->locate($path)) {
+            if (!$file = $this->getLocator()->locate($path)) {
                 throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
             }
 
-            if(is_dir($path)) {
-                $result = $this->__fromDirectory($path);
+            if(is_dir($file)) {
+                $result = $this->__fromDirectory($file);
             } else {
-                $result = $this->__fromFile($path);
+                $result = $this->__fromFile($file);
             }
         }
         else $result =  $this->getObject('com:pages.data.client')->fromUrl($path, false);

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -52,7 +52,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         return $this->__locator;
     }
 
-    public function getData($path, $format = '')
+    public function getData($path)
     {
         $result = array();
         if(!isset($this->__data[$path]))
@@ -81,19 +81,22 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         return $this->__data[$path];
     }
 
-    private function __fromPath($path, $format = '')
+    private function __fromPath($path)
     {
         if(!parse_url($path, PHP_URL_SCHEME) == 'http')
         {
-            //Locate the data file
-            if (!$file = $this->getLocator()->locate('data://'.$path)) {
-                throw new InvalidArgumentException(sprintf('The data "%s" does not exist.', $path));
+            if(!file_exists($path))
+            {
+                //Locate the data file
+                if (!$path = $this->getLocator()->locate($path)) {
+                    throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
+                }
             }
 
-            if(is_dir($file)) {
-                $result = $this->__fromDirectory($file);
+            if(is_dir($path)) {
+                $result = $this->__fromDirectory($path);
             } else {
-                $result = $this->__fromFile($file);
+                $result = $this->__fromFile($path);
             }
         }
         else $result =  $this->getObject('com:pages.data.client')->fromUrl($path, false);

--- a/code/site/components/com_pages/model/filesystem.php
+++ b/code/site/components/com_pages/model/filesystem.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesModelFilesystem extends ComPagesModelCollection
+{
+    protected $_path;
+
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        $this->_path = $config->path;
+    }
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'path'  => '',
+        ]);
+
+        parent::_initialize($config);
+    }
+
+    public function getPath(array $variables = array())
+    {
+        return KHttpUrl::fromTemplate($this->_path, $variables);
+    }
+
+    public function setState(array $values)
+    {
+        //Automatically create states that don't exist yet
+        foreach($values as $name => $value)
+        {
+            if(!$this->getState()->has($name)) {
+                $this->getState()->insert($name, 'string');
+            }
+        }
+
+        return parent::setState($values);
+    }
+
+    public function getData($count = false)
+    {
+       if(!isset($this->_data))
+       {
+           if($path = $this->getPath($this->getState()->getValues())) {
+               $this->_data = $this->getObject('data.registry')->getData((string)$path);
+           }
+       }
+
+       return (array) $this->_data;
+    }
+}

--- a/code/site/components/com_pages/model/filesystem.php
+++ b/code/site/components/com_pages/model/filesystem.php
@@ -49,8 +49,13 @@ class ComPagesModelFilesystem extends ComPagesModelCollection
     {
        if(!isset($this->_data))
        {
-           if($path = $this->getPath($this->getState()->getValues())) {
-               $this->_data = $this->getObject('data.registry')->getData((string)$path);
+           if($path = $this->getPath($this->getState()->getValues()))
+           {
+               if(strpos($path, 'data://') === 0) {
+                   $this->_data = $this->getObject('data.registry')->getData((string)$path, false);
+               } else {
+                   $this->_data = $this->getObject('object.config.factory')->fromFile($path, false);
+               }
            }
        }
 

--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -188,7 +188,7 @@ class ComPagesTemplateDefault extends KTemplate
         return implode(' ', $output);
     }
 
-    protected function _fetchData($path, $format = '')
+    protected function _fetchData($path)
     {
         $result = false;
         if(is_array($path))
@@ -196,13 +196,13 @@ class ComPagesTemplateDefault extends KTemplate
             foreach($path as $directory)
             {
                 if (!$result instanceof ComPagesDataObject) {
-                    $result = $this->getObject('data.registry')->getData($directory, $format);
+                    $result = $this->getObject('data.registry')->getData($directory);
                 } else {
-                    $result->append($this->getObject('data.registry')->getData($directory, $format));
+                    $result->append($this->getObject('data.registry')->getData($directory));
                 }
             }
         }
-        else $result = $this->getObject('data.registry')->getData($path, $format);
+        else $result = $this->getObject('data.registry')->getData($path);
 
         return $result;
     }


### PR DESCRIPTION
## Filesystem collections

This PR implements support for filesystem collections. A collection can now easily be retrieved from any path. The implementation offers support for URI templates to make creating dynamic path easy.

### 1. Defining filesystem collections

A filesystem collection can be defined easily by specifying the path where the collection should be retrieved from. For example:

```yaml
collection:
   source: filesystem?path=data://team/members
```

`filesystem`is a shortcut for `com:pages.model.filesystem`

The `path`parameter defines the location for the filesystem collection and can be templated using the [template URI's](https://tools.ietf.org/html/rfc6570) standard. When  a template uri is used the model state will be used to expand the template url.  For example:

```yaml
collection:
   source: filesystem?path=data://{+path}{/segments*}
   state:
     path: /foo/bar
     segments: ['one', 'two']
```

The resulting URL would become data://foo/bar/one/

For more info see on using template uri's for filesystem collections please see: https://github.com/joomlatools/joomlatools-framework/pull/262

#### Data path

If the `path` starts with data:// it will be loaded through the data registry. More info about the data registry and loading data files see the https://github.com/joomlatools/joomlatools-pages/pull/4

### 2. Custom filesystem collections

The ability to create filesystem collections is provided through extending the `ComPagesModelFilesystem` class. See: https://github.com/joomlatools/joomlatools-pages/blob/0ade451702a23f5c6f5753564883cc1c1261ed72/code/site/components/com_pages/model/filesystem.php