### PR TITLE
Controller collections

### DIFF
--- a/code/site/components/com_pages/model/controller.php
+++ b/code/site/components/com_pages/model/controller.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesModelController extends KModelAbstract
+{
+    protected $_controller;
+
+    public function __construct(KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        $this->_controller = $config->controller;
+    }
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'controller' => '',
+        ));
+
+        parent::_initialize($config);
+    }
+
+    public function getController()
+    {
+        if(!($this->_controller instanceof KControllerInterface))
+        {
+            //Make sure we have a controller identifier
+            if(!($this->_controller instanceof KObjectIdentifier))
+            {
+                if(is_string($this->_controller) && strpos($this->_controller, '.') === false )
+                {
+                    $identifier         = $this->getIdentifier()->toArray();
+                    $identifier['path'] = array('controller');
+                    $identifier['name'] = KStringInflector::underscore($this->_controller);
+
+                    $identifier = $this->getIdentifier($identifier);
+                }
+                else  $identifier = $this->getIdentifier($this->_controller);
+
+                if($identifier->path[0] != 'controller') {
+                    throw new UnexpectedValueException('Identifier: '.$identifier.' is not a controller identifier');
+                }
+
+                $this->_controller = $identifier;
+            }
+
+            $this->_controller = $this->getObject($this->_controller);
+
+            if(!$this->_controller instanceof KControllerModellable)
+            {
+                throw new UnexpectedValueException(
+                    'Controller: '.get_class($this->_controller).' does not implement KControllerModellable'
+                );
+            }
+        }
+
+        return $this->_controller;
+    }
+
+    protected function _actionFetch(KModelContext $context)
+    {
+        if ($this->getState()->isUnique()) {
+            $result =  $this->getController()->read();
+        } else {
+            $result =  $this->getController()->browse();
+        }
+
+        return $result;
+    }
+
+    protected function _actionCount(KModelContext $context)
+    {
+        return $this->getController()->count();
+    }
+}

--- a/code/site/components/com_pages/model/factory.php
+++ b/code/site/components/com_pages/model/factory.php
@@ -29,6 +29,11 @@ class ComPagesModelFactory extends KObject implements KObjectSingleton
 
         if($collection = $this->getObject('page.registry')->getCollection($source))
         {
+            //Set the state
+            if(isset($collection->state)) {
+                $state = KObjectConfig::unbox($collection->state->merge($state));
+            }
+
             //Create the model
             $source = KHttpUrl::fromString($collection->source);
 
@@ -44,19 +49,19 @@ class ComPagesModelFactory extends KObject implements KObjectSingleton
 
             $model = $this->getObject($identifier, $config);
 
-            if(!$model instanceof KModelInterface)
+            if(!$model instanceof KModelInterface && !$model instanceof KControllerModellable)
             {
                 throw new UnexpectedValueException(
-                    'Collection: '.get_class($model).' does not implement KModelInterface'
+                    'Collection: '.get_class($model).' does not implement KModelInterface or KControllerModellable'
                 );
             }
 
-            //Set the state
-            if(isset($collection->state)) {
-                $state  = $collection->state->merge($state);
+            if($model instanceof KControllerModellable)
+            {
+                $model->getModel()->setState($state);
+                $model = $this->getObject('com:pages.model.controller', ['controller' => $model]);
             }
-
-            $model->setState(KObjectConfig::unbox($state));
+            else $model->setState($state);
         }
 
         return $model;


### PR DESCRIPTION
This PR allows to use a model identifier as a collection source. Example:

```yaml
collection:
   source: com:component.controller.item 
   state: []
```

This PR requires: https://github.com/joomlatools/joomlatools-framework/pull/268

