### PR TITLE
Data JSON support

### DIFF
--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesDataObject extends KObjectConfig
+class ComPagesDataObject extends KObjectConfig implements JsonSerializable
 {
     public function shuffle()
     {
@@ -76,8 +76,47 @@ class ComPagesDataObject extends KObjectConfig
         return new self($data);
     }
 
+    public function toString()
+    {
+        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
+        $data = json_encode($this->toArray(), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if (JSON_ERROR_NONE !== json_last_error())
+        {
+            throw new InvalidArgumentException(
+                'Cannot encode data to JSON string: ' . json_last_error_msg()
+            );
+        }
+
+        return $data;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
     public function __debugInfo()
     {
         return self::unbox($this);
+    }
+
+    /**
+     * Allow PHP casting of this object
+     *
+     * @return string
+     */
+    final public function __toString()
+    {
+        $result = '';
+
+        //Not allowed to throw exceptions in __toString() See : https://bugs.php.net/bug.php?id=53648
+        try {
+            $result = $this->toString();
+        } catch (Exception $e) {
+            trigger_error('KObjectConfigFormat::__toString exception: '. (string) $e, E_USER_ERROR);
+        }
+
+        return $result;
     }
 }

--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -193,14 +193,23 @@ class ComPagesTemplateDefault extends KTemplate
         $result = false;
         if(is_array($path))
         {
-            foreach($path as $directory)
+            if(is_numeric(key($path)))
             {
-                if (!$result instanceof ComPagesDataObject) {
-                    $result = $this->getObject('data.registry')->getData($directory);
-                } else {
-                    $result->append($this->getObject('data.registry')->getData($directory));
+                foreach($path as $directory)
+                {
+                    if (!$result instanceof ComPagesDataObject) {
+                        $result = $this->getObject('data.registry')->getData($directory);
+                    } else {
+                        $result->append($this->getObject('data.registry')->getData($directory));
+                    }
                 }
             }
+            else
+            {
+                $class = $this->getObject('manager')->getClass('com:pages.data.object');
+                $result = new $class($path);
+            }
+
         }
         else $result = $this->getObject('data.registry')->getData($path);
 


### PR DESCRIPTION
This PR adds several improvements to the data objects. 

### 1. JSON support

It's now possible to cast a data object to a string. You can do so by calling the `data([..])->toString()` method, or you can cast the the data object to a string `<?= data([...]) ?>`

### 2. Create a data object from an array

It's now possible to create a new data object from an associative array of data. Example

```php
<? $data = data([
    'foo' => 'bar',
    'dog' => 'bark'
]) ?>
```

A none associative array is not supported. This will be interpreted as an array of data locations, see also https://github.com/joomlatools/joomlatools-pages/pull/4

