### PR TITLE
Opengraph support

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -36,8 +36,20 @@ class ComPagesControllerAbstract extends KControllerModel
         if($context->request->getFormat() == 'html')
         {
             //Set the metadata
-            foreach($this->getView()->getMetadata() as $name => $content) {
-                JFactory::getDocument()->setMetaData($name, $content);
+            foreach($this->getView()->getMetadata() as $name => $content)
+            {
+                if($content)
+                {
+                    $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
+
+                    if(strpos($name, 'og:') === 0) {
+                        $tag = sprintf('<meta property="%s" content="%s" />', $name, $content);
+                    } else {
+                        $tag = sprintf('<meta name="%s" content="%s" />', $name, $content);
+                    }
+
+                    JFactory::getDocument()->addCustomTag($tag);
+                }
             }
 
             //Set the title

--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -21,6 +21,7 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
                 'content'     => '',
                 'excerpt'     => '',
                 'text'        => '',
+                'image'       => '',
                 'date'        => 'now',
                 'author'      => '',
                 'published'   => true,
@@ -30,7 +31,13 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
                     'groups' => ['public', 'guest']
                 ],
                 'redirect'    => '',
-                'metadata'    => [],
+                'metadata'    => [
+                    'og:type'        => 'website',
+                    'og:title'       => null,
+                    'og:url'         => null,
+                    'og:image'       => null,
+                    'og:description' => null,
+                ],
                 'process'     => [
                     'filters' => array(),
                 ],
@@ -97,6 +104,32 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
     public function getPropertyRoute()
     {
         return $this->getHandle();
+    }
+
+    public function getPropertyMetadata()
+    {
+        $metadata = $this->getConfig()->data->metadata;
+
+        if(!isset($metadata->description) && $this->summary) {
+            $metadata->set('description', $this->summary);
+        }
+
+        if(!empty($metadata->get('og:type')))
+        {
+            if($this->title) {
+                $metadata->set('og:title', $this->title);
+            }
+
+            if($this->summary) {
+                $metadata->set('og:description', $this->summary);
+            }
+
+            if($this->image) {
+                $metadata->set('og:image', $this->image);
+            }
+        }
+
+        return $metadata;
     }
 
     public function setPropertyName($name)

--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -114,7 +114,8 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
             $metadata->set('description', $this->summary);
         }
 
-        if(!empty($metadata->get('og:type')))
+        //Type and image are required. If they are not set remove any opengraph properties
+        if(!empty($metadata->get('og:type')) && !empty($metadata->get('og:image')))
         {
             if($this->title) {
                 $metadata->set('og:title', $this->title);
@@ -126,6 +127,15 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
 
             if($this->image) {
                 $metadata->set('og:image', $this->image);
+            }
+        }
+        else
+        {
+            foreach($metadata as $name => $value)
+            {
+                if(strpos($name, 'og:') === 0 || strpos($name, 'twitter:') === 0) {
+                    $metadata->remove($name);
+                }
             }
         }
 

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -22,6 +22,7 @@ return array(
         'com:pages.version'     => 'com://admin/pages.version',
         'com:pages.data.object' => 'com://site/pages.data.object',
         'com:pages.data.client' => 'com://site/pages.data.client',
+        'com:pages.model.entity.page' => 'com://site/pages.model.entity.page',
     ],
 
     'identifiers' => [
@@ -81,6 +82,11 @@ return array(
             'cache'      => $config['remote_cache'] ?? (JDEBUG ? false : true),
             'cache_time' => $config['remote_cache_time'] ?? 60*60*24, //1d
             'cache_path' => $config['remote_cache_path'] ?? null
+        ],
+        'com://site/pages.model.entity.page' => [
+            'data' => [
+                'metadata' => $config['metadata'] ?? array(),
+            ]
         ],
     ]
 );

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -151,7 +151,9 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
 
                 if($page->metadata->has('og:type'))
                 {
-                    $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
+                    if(strpos($metadata['og:image'], 'http') === false) {
+                        $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
+                    }
 
                     if(!$metadata['og:url']) {
                         $metadata['og:url'] = (string) $this->getRoute($page);

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -143,15 +143,22 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
     public function getMetadata()
     {
         $metadata = array();
-        if($data = $this->getPage())
+        if($page = $this->getPage())
         {
-            if(isset($data->metadata)) {
-                $metadata = KObjectConfig::unbox($data->metadata);
-            }
+            if($page->metadata)
+            {
+                $metadata = KObjectConfig::unbox($page->metadata);
 
-            //Set the description into the metadata if it doesn't exist.
-            if(!empty($data->summary) && !isset($data->metadata->description)) {
-                $metadata['description'] = $data->summary;
+                if(!empty($page->metadata->get('og:type')))
+                {
+                    if($metadata['og:image']) {
+                        $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
+                    }
+
+                    if(!$metadata['og:url']) {
+                        $metadata['og:url'] = (string) $this->getRoute($page);
+                    }
+                }
             }
         }
 

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -149,11 +149,9 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
             {
                 $metadata = KObjectConfig::unbox($page->metadata);
 
-                if(!empty($page->metadata->get('og:type')))
+                if($page->metadata->has('og:type'))
                 {
-                    if($metadata['og:image']) {
-                        $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
-                    }
+                    $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
 
                     if(!$metadata['og:url']) {
                         $metadata['og:url'] = (string) $this->getRoute($page);


### PR DESCRIPTION
## Opengraph support

This PR implements automatic support for opengraph and additionally twitter cards. For an overview of both standards please see:

- http://ogp.me/#metadata
- https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup

### 1. Default properties

- og:type; defaults to `website`
- og:image; defaults to `page image`
- og:title; defaults to `page title`
- og:description; defaults to `page description`
- og:url, defaults to the `page url`

For opengraph metadata to be added to the page both the `og:type` and `og:image` properties need to be defined.

### 2. Custom properties

Properties can be added or custom values for defaults defined by specifying them in the page frontmatter. Example: 

```yaml
metadata:
   'og:type': article 
```

### 3. Global properties

Default properties can be configured, or additional properties can be added using a new 'metadata' config option. Example: 

```php
return array(
   'metadata' => [
        'og:site_name' => 'Joomlatools',
        'og:image'     => '/images/default_card.jpg',
        'twitter:site' => '@joomlatools',
        'twitter:card' => 'summary_large_image',
     ]
);
```
### 4. Disabling opengraph

Opengraph support can be disabled by setting the 'og:type' metadata property to `false`.

```php
return array(
   'metadata' => [
        'og:type'  => false
     ]
);
```

### Notes

- The `image` should be a site absolute image path, or a url. If it's a path it's transformed into a url when the metadata is being rendered. 

- For twitter we making use of the opengraph properties supported by twitter. For info see: https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup Specific twitter properties need to be defined either in the page frontmatter of in the global configuration.

## Additional improvements

This PR also adds a page ìmage`property.