### PR TITLE
Markdown partials are not rendered correctly

### DIFF
--- a/code/site/components/com_pages/template/filter/partial.php
+++ b/code/site/components/com_pages/template/filter/partial.php
@@ -22,9 +22,10 @@ class ComPagesTemplateFilterPartial extends KTemplateFilterAbstract
                 $engine = $this->getObject('template.engine.factory')
                     ->createEngine($matches[1][$key], array('template' => $this->getTemplate()));
 
-                $result = $engine->loadString($matches[2][$key])->render();
+                $result = $engine->loadString(trim($matches[2][$key]))->render();
 
                 $text = str_replace($match, $result, $text);
+
             }
         }
     }


### PR DESCRIPTION
Trim content to prevent markdown from being rendered inside `<pre><code></code></pre>`elements if the element is not defined at the first column of a document due to additional unwanted whitespace being added as a result of the regex filtering. 