### PR TITLE
Add an image:// scheme

### DIFF
--- a/code/site/components/com_pages/template/filter/asset.php
+++ b/code/site/components/com_pages/template/filter/asset.php
@@ -16,6 +16,7 @@ class ComPagesTemplateFilterAsset extends ComKoowaTemplateFilterAsset
             'priority' => self::PRIORITY_LOW,
             'schemes' => array(
                 'theme://'    => 'basepath://templates/'.JFactory::getApplication()->getTemplate().'/',
+                'image://'    => '/images/',
                 'baseurl://'  => rtrim($this->getObject('request')->getBaseUrl(), '/').'/',
                 'basepath://' => rtrim($this->getObject('request')->getBaseUrl()->getPath(), '/').'/'
             ),


### PR DESCRIPTION
This PR adds a image:// scheme to make it easy to create image paths and make the /images folder configurable. Default is /images

Note to generatea fully qualified image url you can do baseurl://image://[path/to/image]