### PR TITLE
Improve RSS feed

### DIFF
--- a/code/site/components/com_pages/dispatcher/router/abstract.php
+++ b/code/site/components/com_pages/dispatcher/router/abstract.php
@@ -184,7 +184,6 @@ abstract class ComPagesDispatcherRouterAbstract extends KObject implements ComPa
             //Qualify the url
             $url->setUrl($request->getUrl()->toString(KHttpUrl::AUTHORITY));
 
-
             //Add index.php
             $base = $request->getBasePath();
             $path = trim($url->getPath(), '/');

--- a/code/site/components/com_pages/dispatcher/router/resolver/abstract.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/abstract.php
@@ -201,7 +201,8 @@ abstract class ComPagesDispatcherRouterResolverAbstract extends KObject implemen
     public function generate($path, array $query, ComPagesDispatcherRouterInterface $router)
     {
         $route  = false;
-        $routes = array_flip(array_reverse($this->__static_routes));
+
+        $routes = array_flip(array_reverse($this->__static_routes, true));
 
         //Check if we have a static route
         if(!isset($routes[$path]))
@@ -319,7 +320,7 @@ abstract class ComPagesDispatcherRouterResolverAbstract extends KObject implemen
         }
 
         //Create the route
-        $route = $this->getObject('http.url', array('url' => $route))
+        $route = $this->getObject('http.url', array('url' => (string) $route))
                 ->setQuery($query);
 
         return $route;

--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -103,7 +103,14 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
 
     public function getPropertyRoute()
     {
-        return $this->getHandle();
+        $handle = $this->path ? $this->path.'/'.$this->slug : $this->slug;
+
+        //Add the extension
+        if($this->format !== 'html') {
+            $handle .= '.'.$this->format;
+        }
+
+        return $handle;
     }
 
     public function getPropertyMetadata()
@@ -216,8 +223,7 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
 
     public function getHandle()
     {
-        $handle = $this->path ? $this->path.'/'.$this->slug : $this->slug;
-        return $handle;
+        return $this->route;
     }
 
     public function jsonSerialize()

--- a/code/site/components/com_pages/view/collection/rss.php
+++ b/code/site/components/com_pages/view/collection/rss.php
@@ -13,7 +13,7 @@ class ComPagesViewCollectionRss extends ComPagesViewCollectionXml
     {
         $config->append(array(
             'data'     => array(
-                'update_period'    => 'hourly',
+                'update_period'    => 'daily',
                 'update_frequency' => 1
             )
         ));

--- a/code/site/components/com_pages/view/collection/rss.php
+++ b/code/site/components/com_pages/view/collection/rss.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesViewCollectionRss extends ComPagesViewXml
+class ComPagesViewCollectionRss extends ComPagesViewCollectionXml
 {
     protected function _initialize(KObjectConfig $config)
     {
@@ -24,10 +24,7 @@ class ComPagesViewCollectionRss extends ComPagesViewXml
     protected function _fetchData(KViewContext $context)
     {
         $context->data->append(array(
-            'sitename'     => JFactory::getApplication()->getCfg('sitename'),
-            'language'     => JFactory::getLanguage()->getTag(),
-            'description'  => $this->getPage()->summary ?: '',
-            'image'        => $this->getPage()->image ?: ''
+            'language' => JFactory::getLanguage()->getTag(),
         ));
 
         parent::_fetchData($context);

--- a/code/site/components/com_pages/view/collection/tmpl/newsfeed.rss.php
+++ b/code/site/components/com_pages/view/collection/tmpl/newsfeed.rss.php
@@ -11,17 +11,18 @@ defined('KOOWA') or die; ?>
 
 <rss version="2.0"
      xmlns:atom="http://www.w3.org/2005/Atom"
-     xmlns:sy="http://purl.org/rss/1.0/modules/syndication/">
+     xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+     xmlns:media="http://search.yahoo.com/mrss/">
 
     <channel>
-        <title><?= translate('Pages') ?> - <?= escape($sitename)?></title>
-        <description><![CDATA[<?= $description ?>]]></description>
-        <link><?= url() ?></link>
-        <? if (!empty($image)): ?>
+        <title><?= page()->title ?></title>
+        <description><?= page()->summary ?></description>
+        <link><?= route(page()->path.'/'.page()->slug) ?></link>
+        <? if (!empty($page->image)): ?>
             <image>
-                <url><?=$image?></url>
-                <title><?= translate('Pages') ?> - <?= escape($sitename)?></title>
-                <link><?= route('format=html') ?></link>
+                <url>baseurl://image://<?= $page->image ?></url>
+                <title><<?= page()->title ?></title>
+                <link><?= route(page()->path.'/'.page()->slug) ?></link>
             </image>
         <? endif; ?>
         <lastBuildDate><?= count(collection()) ? collection()->top()->date->format(DateTime::RSS) : '' ?></lastBuildDate>
@@ -35,14 +36,13 @@ defined('KOOWA') or die; ?>
                 <title><?= escape($page->title); ?></title>
                 <link><?= route($page); ?></link>
                 <guid isPermaLink="true"><?= route($page); ?></guid>
-                <description><![CDATA[
-                 <? if($page->image): ?>
-                    <img width="800" href="<?= $page->image ?>" />
-                 <? endif ?>
-                 <?= $page->content ?>
-                ?>]]></description>
-                <author><?= escape($page->author) ?></author>
-                <category><?= escape($page->category) ?></category>
+                <? if($page->image): ?>
+                    <media:content medium="image" url="baseurl://image://<?= $page->image ?>" />
+                <? endif ?>
+                <description><?=  escape($page->summary) ?></description>
+                <? if($page->category): ?>
+                    <category><?= escape($page->category) ?></category>
+                <? endif; ?>
                 <pubDate><?= $page->date->format(DateTime::RSS) ?></pubDate>
             </item>
         <?endforeach?>

--- a/code/site/components/com_pages/view/xml.php
+++ b/code/site/components/com_pages/view/xml.php
@@ -119,7 +119,7 @@ class ComPagesViewXml extends KViewTemplate
     public function getCollection($source = '', $state = array())
     {
         if($source) {
-            $result = $this->getObject('com:pages.model.factory')->getCollection($source, $state)->fetch();
+            $result = $this->getObject('com:pages.model.factory')->createCollection($source, $state)->fetch();
         } else {
             $result = $this->getModel()->fetch();
         }
@@ -132,10 +132,10 @@ class ComPagesViewXml extends KViewTemplate
         return $this->getModel()->getState();
     }
 
-    public function getRoute($page = '', $query = array(), $escape = false)
+    public function getRoute($page, $query = array(), $escape = false)
     {
-        if(empty($page)) {
-            $page = $this->getPage();
+        if(!is_array($query)) {
+            $query = array();
         }
 
         if($route = $this->getObject('dispatcher')->getRouter()->generate($page, $query)) {


### PR DESCRIPTION
This PR fixes issues with and improves the RSS feed support to bring it as close as possible to the RSS specification: https://validator.w3.org/feed/docs/rss2.html

The item image is now embedded using media RSS specification: http://www.rssboard.org/media-rss instead of injecting into the description.

The channel or item description is based on the page or item summary and no longer contains html entities to stay as close to the original specification as possible.
