### PR TITLE
Refactor sitemap handling

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -40,6 +40,7 @@ class ComPagesControllerAbstract extends KControllerModel
             {
                 if($content)
                 {
+                    $content =  is_array($content) ? implode(', ', $content) : $content;
                     $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
 
                     if(strpos($name, 'og:') === 0) {

--- a/code/site/components/com_pages/model/pages.php
+++ b/code/site/components/com_pages/model/pages.php
@@ -21,7 +21,6 @@ class ComPagesModelPages extends ComPagesModelCollection
             //Filter states
             ->insert('visible', 'boolean')
             ->insert('collection', 'boolean')
-            ->insert('sitemap', 'boolean')
             ->insert('category', 'cmd')
             ->insert('year', 'int')
             ->insert('month', 'int')
@@ -113,11 +112,6 @@ class ComPagesModelPages extends ComPagesModelCollection
             if($state->collection === false) {
                 $result = !isset($page['collection']) || $page['collection'] === false;
             }
-        }
-
-        //Sitemap
-        if($result && (bool) $state->sitemap) {
-            $result = (isset($page['sitemap']) && $page['sitemap'] == false) ? false : true;
         }
 
         //Category

--- a/code/site/components/com_pages/view/collection/tmpl/sitemap.xml.php
+++ b/code/site/components/com_pages/view/collection/tmpl/sitemap.xml.php
@@ -14,10 +14,12 @@ defined('KOOWA') or die; ?>
         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
     <? foreach(collection() as $page): ?>
+    <? if(!$page->metadata->has('robots') || !in_array('noindex', (array) KObjectConfig::unbox($page->metadata->robots))): ?>
     <url>
         <loc><?= route($page) ?></loc>
         <lastmod><?= $page->date->format(DateTime::ATOM) ?></lastmod>
     </url>
+    <? endif; ?>
     <? endforeach ?>
 
 </urlset>


### PR DESCRIPTION
This PR removed the 'sitemap' pages collection state. Instead a page is not included in the sitemap if it has robots: noindex defined. 

If you wish to define robots in your metadata you need to define it as an array 

```yaml
metadata:
    robots: [noindex, nofollow]
```

Note: as part of the this PR a metadata property now accepts array values, if an array is defined thit will be imploded using a ',' separator. 