### PR TITLE
Sitemap doesn't contain all pages

### DIFF
--- a/code/site/components/com_pages/model/pages.php
+++ b/code/site/components/com_pages/model/pages.php
@@ -59,7 +59,13 @@ class ComPagesModelPages extends ComPagesModelCollection
                 }
                 else
                 {
-                    $pages = array_values($registry->getPages($path, $state->recurse, $state->level - 1));
+                    if($state->recurse) {
+                        $mode = ComPagesPageRegistry::PAGES_ONLY;
+                    } else {
+                        $mode = ComPagesPageRegistry::PAGES_TREE;
+                    }
+
+                    $pages = array_values($registry->getPages($path, $mode, $state->level - 1));
 
                     //Filter the pages
                     $pages = array_filter($pages, function($page) use ($state) {

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -9,8 +9,8 @@
 
 class ComPagesPageRegistry extends KObject implements KObjectSingleton
 {
-    const PAGES_ONLY = \RecursiveIteratorIterator::LEAVES_ONLY;
     const PAGES_TREE = \RecursiveIteratorIterator::SELF_FIRST;
+    const PAGES_ONLY = \RecursiveIteratorIterator::CHILD_FIRST;
 
     private  $__locator = null;
 
@@ -349,8 +349,10 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
                                     //Route
                                     $routes[$route] = (array) KObjectConfig::unbox($page->route);
 
-                                    //File
-                                    $files[$route] = $file;
+                                    //File (do not include index pages)
+                                    if(strpos($file, '/index') === false) {
+                                        $files[$route] = $file;
+                                    }
 
                                     //Collection
                                     if($collection = $page->isCollection()) {


### PR DESCRIPTION
This PR fixes two issues:

1. The 'index' pages are not in the sitemap. To test http://joomlatools.com/extensions was not present, this should be fixed now. Do also confirm that the http://joomlatools.com is still present

2. As a result of a previous fix the index pages got included in the navigation while they should only have been included in the sitemap. To test ensure that we don't have double menu items anymore.