### PR TITLE
Add support for dir attribute

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -57,6 +57,11 @@ class ComPagesControllerAbstract extends KControllerModel
             if($title = $this->getView()->getTitle()) {
                 JFactory::getDocument()->setTitle($title);
             }
+
+            //Set the direction
+            if($direction = $this->getView()->getDirection()) {
+                JFactory::getDocument()->setDirection($direction);
+            }
         }
     }
 

--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -43,6 +43,7 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
                 ],
                 'layout'      => array(),
                 'colllection' => false,
+                'direction'   => 'auto',
             ],
         ]);
 

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -165,6 +165,16 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
         return $metadata;
     }
 
+    public function getDirection()
+    {
+        $result = '';
+        if($page = $this->getPage()) {
+            $result = $page->direction ? $page->direction :  'auto';
+        }
+
+        return $result;
+    }
+
     public function getRoute($page, $query = array(), $escape = false)
     {
         if(!is_array($query)) {


### PR DESCRIPTION
This PR adds support for setting the page direction. The direction can be defined through the page frontmatter 'direction' option.

```yaml
collection: [auto|ltr|rtl]
```

By default the direction is set to 'auto' which is supported by all html5 capable browsers. For more info see: https://www.w3.org/International/questions/qa-html-dir#dirauto