### PR TITLE
Internal redirect should be a 307

### DIFF
--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -62,7 +62,7 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
 
         //Send redirect 
         if($context->response->isRedirect()) {
-            $this->redirect($route);
+            $this->send($route);
         }
 
         //Get the page from the router

--- a/code/site/components/com_pages/dispatcher/router/resolver/redirect.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/redirect.php
@@ -36,11 +36,20 @@ class ComPagesDispatcherRouterResolverRedirect extends ComPagesDispatcherRouterR
     {
         if($route = parent::resolve($router))
         {
-            //Set the location header
-            $router->getResponse()->getHeaders()->set('Location', (string) $router->qualifyUrl($route));
+            if($route->toString(KHttpUrl::AUTHORITY))
+            {
+                //External redierct: 301 permanent
+                $status   = KHttpResponse::MOVED_PERMANENTLY;
+            }
+            else
+            {
+                //Internal redirect: 307 temporary
+                $status = KHttpResponse::TEMPORARY_REDIRECT;
+            }
 
-            //Set the 301 status
-            $router->getResponse()->setStatus(KHttpResponse::MOVED_PERMANENTLY);
+            //Set the location header
+            $router->getResponse()->getHeaders()->set('Location',  (string) $router->qualifyUrl($route));
+            $router->getResponse()->setStatus($status);
         }
 
         return $route;


### PR DESCRIPTION
This PR allows for internal and external redirects.

- **internal redirect:** should point to an internal page path and not use a url, the redirect will use a  307 status code and is temporary

- **external redirect:** should point to an external url and not use a page path, the redirect will use a 301 status code and is permanent. 
