### PR TITLE
Do not require an index file

### DIFF
--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -222,7 +222,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
                 $files = array();
 
                 //Only include pages
-                if(is_dir($dir) && !empty(glob($dir.'/index*')))
+                if(is_dir($dir) && !file_exists($dir.'/.ignore'))
                 {
                     //List
                     foreach (new DirectoryIterator($dir) as $node)


### PR DESCRIPTION
This PR changes the pages registry indexing and will index every directory regardless if the directory has a 'index.*' file or not. To prevent a folder from being indexed, add a .ignore file to the directory.