### PR TITLE
Theme support

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -34,24 +34,6 @@ class ComPagesControllerAbstract extends KControllerModel
         //Set metadata
         if($context->request->getFormat() == 'html')
         {
-            //Set the metadata
-            foreach($this->getView()->getMetadata() as $name => $content)
-            {
-                if($content)
-                {
-                    $content =  is_array($content) ? implode(', ', $content) : $content;
-                    $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
-
-                    if(strpos($name, 'og:') === 0) {
-                        $tag = sprintf('<meta property="%s" content="%s" />', $name, $content);
-                    } else {
-                        $tag = sprintf('<meta name="%s" content="%s" />', $name, $content);
-                    }
-
-                    JFactory::getDocument()->addCustomTag($tag);
-                }
-            }
-
             //Set the title
             if($title = $this->getView()->getTitle()) {
                 JFactory::getDocument()->setTitle($title);
@@ -60,6 +42,11 @@ class ComPagesControllerAbstract extends KControllerModel
             //Set the direction
             if($direction = $this->getView()->getDirection()) {
                 JFactory::getDocument()->setDirection($direction);
+            }
+
+            //Set the language
+            if($language = $this->getView()->getLanguage()) {
+                JFactory::getDocument()->setLanguage($language);
             }
         }
     }

--- a/code/site/components/com_pages/dispatcher/behavior/decoratable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/decoratable.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesDispatcherBehaviorDecoratable extends ComKoowaDispatcherBehaviorDecoratable
+{
+    protected function _beforeSend(KDispatcherContextInterface $context)
+    {
+        $response = $context->getResponse();
+
+        if(!$response->isDownloadable() && !$response->isRedirect())
+        {
+            $controller = $this->getObject('com:koowa.controller.page',  array('response' => $response));
+
+            $controller->getView()
+                ->setDecorator($this->getDecorator())
+                ->setLayout('joomla');
+
+            $content = $controller->render();
+
+            //Set the result in the response
+            $response->setContent($content);
+        }
+    }
+
+    public function getDecorator()
+    {
+        $content = $this->getResponse()->getContent();
+
+        //Do not decorate if we are outputting a html document
+        if(strpos($content, '<head>') === false) {
+            $result = 'joomla';
+        } else {
+            $result = 'koowa';
+        }
+
+        return $result;
+    }
+}

--- a/code/site/components/com_pages/dispatcher/behavior/decoratable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/decoratable.php
@@ -33,7 +33,7 @@ class ComPagesDispatcherBehaviorDecoratable extends ComKoowaDispatcherBehaviorDe
         $content = $this->getResponse()->getContent();
 
         //Do not decorate if we are outputting a html document
-        if(preg_match('#<html(.*)\/>#siU', $content) === false) {
+        if(!preg_match('#<html(.*)\/>#siU', $content)) {
             $result = 'joomla';
         } else {
             $result = 'koowa';

--- a/code/site/components/com_pages/dispatcher/behavior/decoratable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/decoratable.php
@@ -33,7 +33,7 @@ class ComPagesDispatcherBehaviorDecoratable extends ComKoowaDispatcherBehaviorDe
         $content = $this->getResponse()->getContent();
 
         //Do not decorate if we are outputting a html document
-        if(strpos($content, '<head>') === false) {
+        if(preg_match('#<html(.*)\/>#siU', $content) === false) {
             $result = 'joomla';
         } else {
             $result = 'koowa';

--- a/code/site/components/com_pages/dispatcher/router/resolver/site.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/site.php
@@ -43,8 +43,10 @@ class ComPagesDispatcherRouterResolverSite extends ComPagesDispatcherRouterResol
                 $base_path = $route->getPath();
                 $path      = $this->getObject('object.bootstrapper')->getComponentPath('pages');
 
+                //Load config options
                 $options = include $path.'/resources/config/options.php';
 
+                //Set config options
                 foreach($options['identifiers'] as $identifier => $values) {
                     $this->getConfig($identifier)->merge($values);
                 }
@@ -66,7 +68,7 @@ class ComPagesDispatcherRouterResolverSite extends ComPagesDispatcherRouterResol
             //Configure the template
             if(isset($config['template']) || isset($config['template_config']))
             {
-                if(isset($config['template']) && $config['template'] != false)
+                if(isset($config['template']))
                 {
                     if(isset($config['template'])) {
                         $template = $config['template'];
@@ -82,7 +84,6 @@ class ComPagesDispatcherRouterResolverSite extends ComPagesDispatcherRouterResol
 
                     JFactory::getApplication()->setTemplate($template, $params);
                 }
-                else $router->getResponse()->getRequest()->headers->set('X-Flush-Response', 1);
             }
         }
 

--- a/code/site/components/com_pages/dispatcher/router/resolver/site.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/site.php
@@ -68,22 +68,19 @@ class ComPagesDispatcherRouterResolverSite extends ComPagesDispatcherRouterResol
             //Configure the template
             if(isset($config['template']) || isset($config['template_config']))
             {
-                if(isset($config['template']))
-                {
-                    if(isset($config['template'])) {
-                        $template = $config['template'];
-                    } else {
-                        $template = JFactory::getApplication()->getTemplate();
-                    }
-
-                    if(isset($config['template_config']) && is_array($config['template_config'])) {
-                        $params = $config['template_config'];
-                    } else {
-                        $params = null;
-                    }
-
-                    JFactory::getApplication()->setTemplate($template, $params);
+                if(isset($config['template'])) {
+                    $template = $config['template'];
+                } else {
+                    $template = JFactory::getApplication()->getTemplate();
                 }
+
+                if(isset($config['template_config']) && is_array($config['template_config'])) {
+                    $params = $config['template_config'];
+                } else {
+                    $params = null;
+                }
+
+                JFactory::getApplication()->setTemplate($template, $params);
             }
         }
 

--- a/code/site/components/com_pages/event/subscriber/htmlpurifier.php
+++ b/code/site/components/com_pages/event/subscriber/htmlpurifier.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesEventSubscriberHtmlpurifier extends KEventSubscriberAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'priority' => KEvent::PRIORITY_LOW,
+            'indent'         => true,
+            'vertical-space' => true,
+            'wrap'           => 0,
+            'drop-empty-elements' => false,
+            'coerce-endtags'      => false,
+            'beautify'            => JDEBUG ? true : false,
+        ));
+
+        parent::_initialize($config);
+    }
+
+    public function onBeforeDispatcherSend(KEventInterface $event)
+    {
+        if(class_exists('Tidy') && $this->getConfig()->beautify)
+        {
+            $content = $event->getTarget()->getResponse()->getContent();
+
+            if($result = $this->_beautifyHtml($content)) {
+                $event->getTarget()->getResponse()->setContent($result);
+            }
+        }
+    }
+
+    public function onAfterApplicationRender(KEventInterface $event)
+    {
+        if(class_exists('Tidy') && $this->getConfig()->beautify)
+        {
+            $body   = $event->getTarget()->getBody();
+
+            if($result = $this->_beautifyHtml($body)) {
+                $event->getTarget()->setBody($result);
+            }
+        }
+    }
+
+    protected function _beautifyHtml($content)
+    {
+        $result = false;
+
+        if(strpos($content, '<head>'))
+        {
+            $tidy = new Tidy();
+            $tidy->parseString($content,  $this->getConfig()->toArray(), 'utf8');
+
+            $result = (string) $tidy;
+        }
+
+        return $result;
+    }
+}
+

--- a/code/site/components/com_pages/event/subscriber/pagedecorator.php
+++ b/code/site/components/com_pages/event/subscriber/pagedecorator.php
@@ -7,7 +7,7 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesEventSubscriberDecorator extends KEventSubscriberAbstract
+class ComPagesEventSubscriberPagedecorator extends KEventSubscriberAbstract
 {
     protected function _initialize(KObjectConfig $config)
     {

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -108,8 +108,9 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
             {
                 if(!is_string($file))
                 {
+                    //Do not include a directory without an index file (no existing page)
                     if(!$file = $this->getLocator()->locate('page://pages/'. $page)) {
-                        throw new RuntimeException(sprintf('The page "%s"does not exist.', $page));
+                        continue;
                     }
                 }
 

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -50,7 +50,6 @@ $default = [
         'event.subscriber.factory' => [
             'subscribers' => [
                 'com:pages.event.subscriber.pagedecorator',
-                'com:pages.event.subscriber.htmlpurifier',
             ]
         ],
         'lib:template.engine.markdown' => [

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -48,7 +48,10 @@ $default = [
             ]
         ],
         'event.subscriber.factory' => [
-            'subscribers' => ['com:pages.event.subscriber.decorator']
+            'subscribers' => [
+                'com:pages.event.subscriber.pagedecorator',
+                'com:pages.event.subscriber.htmlpurifier',
+            ]
         ],
         'lib:template.engine.markdown' => [
             'compiler' => function($text) {

--- a/code/site/components/com_pages/resources/config/options.php
+++ b/code/site/components/com_pages/resources/config/options.php
@@ -10,6 +10,18 @@
 return [
 
     'identifiers' => [
+        'com:pages.page.locator' => [
+            'base_path' => $base_path
+        ],
+        'com:pages.data.locator' => [
+            'base_path' => $base_path.'/data'
+        ],
+        'com:pages.template.locator.theme' => [
+            'base_path' => $base_path.'/theme',
+        ],
+        'com://site/pages.template.filter.asset' => [
+            'schemes' =>  $config['aliases'] ?? array()
+        ],
         'page.registry' => [
             'cache'       => $config['page_cache'] ?? (JDEBUG ? false : true),
             'cache_time'  => $config['page_cache_time'] ?? 60*60*24, //1d
@@ -17,17 +29,11 @@ return [
             'collections' => $config['collections'] ?? array(),
             'redirects'   => isset($config['redirects']) ? array_flip($config['redirects']) : array(),
         ],
-        'com:pages.page.locator' => [
-            'base_path' => $base_path
-        ],
         'data.registry' => [
             'cache'      => $config['data_cache'] ?? (JDEBUG ? false : true),
             'cache_time' => $config['data_cache_time'] ?? 60*60*24, //1d
             'cache_path' => $config['data_cache_path'] ?? $base_path.'/cache',
         ],
-        'com:pages.data.locator' => [
-            'base_path' => $base_path.'/data'
-         ],
         'template.engine.factory' => [
             'cache'      => $config['template_cache'] ?? (JDEBUG ? false : true),
             'cache_path' => $config['template_cache_path'] ?? $base_path.'/cache',

--- a/code/site/components/com_pages/template/filter/asset.php
+++ b/code/site/components/com_pages/template/filter/asset.php
@@ -15,8 +15,8 @@ class ComPagesTemplateFilterAsset extends ComKoowaTemplateFilterAsset
         $config->append(array(
             'priority' => self::PRIORITY_LOW,
             'schemes' => array(
-                'theme://'    => 'basepath://templates/'.JFactory::getApplication()->getTemplate().'/',
                 'image://'    => '/images/',
+                'theme://'    => 'basepath://joomlatools-pages/theme/',
                 'baseurl://'  => rtrim($this->getObject('request')->getBaseUrl(), '/').'/',
                 'basepath://' => rtrim($this->getObject('request')->getBaseUrl()->getPath(), '/').'/'
             ),

--- a/code/site/components/com_pages/template/filter/meta.php
+++ b/code/site/components/com_pages/template/filter/meta.php
@@ -7,14 +7,12 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesTemplateFilterMeta extends ComKoowaTemplateFilterMeta
+class ComPagesTemplateFilterMeta extends KTemplateFilterAbstract
 {
-    protected function _parseTags(&$text)
+    public function filter(&$text)
     {
-        $tags = parent::_parseTags($text);
-
-        //Set the metadata
         $meta = array();
+
         foreach($this->_getMetadata() as $name => $content)
         {
             if($content)
@@ -23,16 +21,14 @@ class ComPagesTemplateFilterMeta extends ComKoowaTemplateFilterMeta
                 $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
 
                 if(strpos($name, 'og:') === 0) {
-                    $meta[] = sprintf('<meta content="%s" property="%s" />', $content,  $name);
+                    $meta[] = sprintf('<meta property="%s" content="%s" />', $content,  $name);
                 } else {
-                    $meta[]  = sprintf('<meta content="%s" name="%s" />', $content, $name);
+                    $meta[]  = sprintf('<meta name="%s" content="%s" />', $content, $name);
                 }
             }
         }
 
-        $tags = $tags.implode("\n", $meta);
-
-        return $tags;
+        $text = str_replace('<ktml:meta:page>', implode("", $meta), $text);
     }
 
     protected function _getMetadata()

--- a/code/site/components/com_pages/template/filter/meta.php
+++ b/code/site/components/com_pages/template/filter/meta.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesTemplateFilterMeta extends ComKoowaTemplateFilterMeta
+{
+    protected function _parseTags(&$text)
+    {
+        $tags = parent::_parseTags($text);
+
+        //Set the metadata
+        $meta = array();
+        foreach($this->_getMetadata() as $name => $content)
+        {
+            if($content)
+            {
+                $content =  is_array($content) ? implode(', ', $content) : $content;
+                $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
+
+                if(strpos($name, 'og:') === 0) {
+                    $meta[] = sprintf('<meta content="%s" property="%s" />', $content,  $name);
+                } else {
+                    $meta[]  = sprintf('<meta content="%s" name="%s" />', $content, $name);
+                }
+            }
+        }
+
+        $tags = $tags.implode("\n", $meta);
+
+        return $tags;
+    }
+
+    protected function _getMetadata()
+    {
+        $metadata = array();
+        if($page = $this->getTemplate()->page())
+        {
+            if($page->metadata)
+            {
+                $metadata = KObjectConfig::unbox($page->metadata);
+
+                if($page->metadata->has('og:type'))
+                {
+                    if(strpos($metadata['og:image'], 'http') === false) {
+                        $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
+                    }
+
+                    if(!$metadata['og:url']) {
+                        $metadata['og:url'] = (string) $this->getTemplate()->route($page);
+                    }
+                }
+            }
+        }
+
+        return $metadata;
+    }
+}

--- a/code/site/components/com_pages/template/filter/meta.php
+++ b/code/site/components/com_pages/template/filter/meta.php
@@ -11,24 +11,32 @@ class ComPagesTemplateFilterMeta extends KTemplateFilterAbstract
 {
     public function filter(&$text)
     {
-        $meta = array();
+        static $included;
 
-        foreach($this->_getMetadata() as $name => $content)
+        //Ensure we are only including the page metadata once
+        if(!$included)
         {
-            if($content)
-            {
-                $content =  is_array($content) ? implode(', ', $content) : $content;
-                $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
+            $meta = array();
 
-                if(strpos($name, 'og:') === 0) {
-                    $meta[] = sprintf('<meta property="%s" content="%s" />', $content,  $name);
-                } else {
-                    $meta[]  = sprintf('<meta name="%s" content="%s" />', $content, $name);
+            foreach($this->_getMetadata() as $name => $content)
+            {
+                if($content)
+                {
+                    $content =  is_array($content) ? implode(', ', $content) : $content;
+                    $content =  htmlspecialchars($content, ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8', false);
+
+                    if(strpos($name, 'og:') === 0) {
+                        $meta[] = sprintf('<meta property="%s" content="%s" />', $content,  $name);
+                    } else {
+                        $meta[]  = sprintf('<meta name="%s" content="%s" />', $content, $name);
+                    }
                 }
             }
-        }
 
-        $text = str_replace('<ktml:meta:page>', implode("", $meta), $text);
+            $text = implode("", $meta).$text;
+
+            $included = true;
+        }
     }
 
     protected function _getMetadata()

--- a/code/site/components/com_pages/template/filter/whitespace.php
+++ b/code/site/components/com_pages/template/filter/whitespace.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Joomlatools Framework - https://www.joomlatools.com/developer/framework/
+ *
+ * @copyright   Copyright (C) 2007 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-framework for the canonical source repository
+ */
+
+class ComPagesTemplateFilterWhitespace extends KTemplateFilterWhitespace
+{
+    public function filter(&$text)
+    {
+        $text = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $text);
+        //$text = trim(preg_replace('/>\s+</', '><', $text));
+    }
+}

--- a/code/site/components/com_pages/template/locator/theme.php
+++ b/code/site/components/com_pages/template/locator/theme.php
@@ -13,10 +13,8 @@ class ComPagesTemplateLocatorTheme extends KTemplateLocatorFile
 
     protected function _initialize(KObjectConfig $config)
     {
-        $template  = JFactory::getApplication()->getTemplate();
-
         $config->append([
-            'base_path' =>  JPATH_THEMES.'/'.$template,
+            'base_path' =>  JPATH_ROOT.'/joomlatools-pages/theme'
         ]);
 
         parent::_initialize($config);

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -13,7 +13,7 @@ class ComPagesViewHtml extends ComKoowaViewHtml
     {
         $config->append([
             'auto_fetch'  => false,
-            'template_filters' => ['asset', 'meta'], //Redefine asset to run before the script filter
+            'template_filters' => ['asset', 'meta', 'whitespace'],
             'template_functions' => [
                 'page'        => [$this, 'getPage'],
                 'collection'  => [$this, 'getCollection'],

--- a/code/site/components/com_pages/view/html.php
+++ b/code/site/components/com_pages/view/html.php
@@ -7,18 +7,19 @@
  * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
  */
 
-class ComPagesViewHtml extends ComKoowaViewPageHtml
+class ComPagesViewHtml extends ComKoowaViewHtml
 {
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
             'auto_fetch'  => false,
-            'decorator'   => 'joomla',
-            'template_filters' => ['asset'], //Redefine asset to run before the script filter
+            'template_filters' => ['asset', 'meta'], //Redefine asset to run before the script filter
             'template_functions' => [
                 'page'        => [$this, 'getPage'],
                 'collection'  => [$this, 'getCollection'],
-                'state'       => [$this, 'getState']
+                'state'       => [$this, 'getState'],
+                'direction'   => [$this, 'getDirection'],
+                'language'    => [$this, 'getLanguage'],
             ],
         ]);
 
@@ -140,31 +141,6 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
         return $result;
     }
 
-    public function getMetadata()
-    {
-        $metadata = array();
-        if($page = $this->getPage())
-        {
-            if($page->metadata)
-            {
-                $metadata = KObjectConfig::unbox($page->metadata);
-
-                if($page->metadata->has('og:type'))
-                {
-                    if(strpos($metadata['og:image'], 'http') === false) {
-                        $metadata['og:image'] = rtrim($this->getObject('request')->getBaseUrl(), '/').'/'.ltrim($metadata['og:image'], '/');
-                    }
-
-                    if(!$metadata['og:url']) {
-                        $metadata['og:url'] = (string) $this->getRoute($page);
-                    }
-                }
-            }
-        }
-
-        return $metadata;
-    }
-
     public function getDirection()
     {
         $result = '';
@@ -173,6 +149,11 @@ class ComPagesViewHtml extends ComKoowaViewPageHtml
         }
 
         return $result;
+    }
+
+    public function getLanguage()
+    {
+        return JFactory::getDocument()->language ?? 'en-GB';
     }
 
     public function getRoute($page, $query = array(), $escape = false)


### PR DESCRIPTION
## Theme support

This PR implements theme support for pages. A default installation of pages can include a /theme folder to facilitate loading of specific assets (css, js,and images ...), and additionally it is now possible to  completely control the html output, bypassing the Joomla template system.

### New /theme directory

The /theme directory can be used to load assets. The theme:// template alias allow to easily define urls that point to the theme directory.

### Custom template

Pages now provides complete control over the generated html and can run outside of the context of the active Joomla template.  

To do so render a complete html document. Pages will detect the presence of a `<html>` element and if it does will output the page directly, not forwarding it to Joomla for further processing.

## Configuration options

#### 1. aliases

The `aliases` config setting allows to define the route used for `theme://`. By default this will point to /joomlatools-pages/theme directory. If however you are using server level rewrites you can re-define the default route used.

````php
'aliases' => [
        'theme://' => '/theme/',
    ],
````
## Additional improvements

- A whitespace filter has been added and enabled by default. The filter will strip empty lines from the produced output.