### PR TITLE
Custom error pages

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -20,13 +20,7 @@ class ComPagesControllerAbstract extends KControllerModel
 
     public function getFormats()
     {
-        if($this->getObject('dispatcher')->getRouter()->resolve()) {
-            $formats = array($this->getRequest()->getFormat());
-        }  else {
-            $formats = array();
-        }
-
-        return $formats;
+        return  array($this->getRequest()->getFormat());
     }
 
     protected function _afterRender(KControllerContextInterface $context)

--- a/code/site/components/com_pages/event/subscriber/errorhandler.php
+++ b/code/site/components/com_pages/event/subscriber/errorhandler.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesEventSubscriberErrorhandler extends KEventSubscriberAbstract
+{
+    public function __construct( KObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        //Exception Handling
+        $this->getObject('event.publisher')->addListener('onException', array($this, 'onException'));
+    }
+
+    public function onException(KEventException $event)
+    {
+        if(!JDEBUG && $this->getObject('request')->getFormat() == 'html')
+        {
+            if($this->getObject('com://site/pages.dispatcher.http')->fail($event)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -302,7 +302,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
                                     }
 
                                     //Set the route
-                                    if (!$page->route) {
+                                    if (!$page->route && $page->route !== false) {
                                         $page->route = $route;
                                     }
 
@@ -347,8 +347,11 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
                                     //Page
                                     $pages[$file] = $page->toArray();
 
+
                                     //Route
-                                    $routes[$route] = (array) KObjectConfig::unbox($page->route);
+                                    if($page->route !== false) {
+                                        $routes[$route] = (array) KObjectConfig::unbox($page->route);
+                                    }
 
                                     //File (do not include index pages)
                                     if(strpos($file, '/index') === false) {

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -50,6 +50,7 @@ $default = [
         'event.subscriber.factory' => [
             'subscribers' => [
                 'com:pages.event.subscriber.pagedecorator',
+                'com:pages.event.subscriber.errorhandler',
             ]
         ],
         'lib:template.engine.markdown' => [


### PR DESCRIPTION
## Customer error pages

This PR implements support for custom error pages.  If an error happens pages will look for a error page in the pages root folder `/joomlatools-pages/pages` The error page should return a complete html document.

### Adding custom error pages

Custom error pages need to be added to the root ‘/pages’, the page name should match the error code.  For example. In case of a `404 - Not Found` error pages will look for `/joomlatools-pages/pages/404.html` page.

#### Fallbacks

- If  a matching error page for the error code cannot be found Pages will fallback and look for the 500.html.php

- If no error page exists Pages will let Joomla handle the error instead. 

#### Un-routable errors

In case you don’t want the error page to be routable, aka accessible through the browser you can set the page route to `false`

Example:

```yaml
---
route: false
title: 404 Page not found
summary: Oops! This page can't be found!
visible: false
metadata:
    og:type: false
    robots: [noindex, nofollow]
---
````

## Additional improvements

- This PR adds support for un-routable pages. If you set the `route: false` in the frontmatter the page will not be addressable to the url. It will only be accessible through code, for example by using the `page()`template function.


