### PR TITLE
Add snippets support

### DIFF
--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -108,8 +108,8 @@ class ComPagesTemplateDefault extends KTemplate
         if(!empty($parts)) {
             $identifier = implode('.', $parts).'.template.helper.'.$identifier;
         }
-
-        $helper = $this->createHelper($identifier, $params);
+        
+        $helper = $this->createHelper($identifier);
 
         //Call the helper function
         if (!is_callable(array($helper, $function))) {

--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -121,7 +121,13 @@ class ComPagesTemplateDefault extends KTemplate
             $params = array_merge($this->getParameters()->toArray(), $params);
         }
 
-        return $helper->$function(...$params);
+        if(is_numeric(key($params))) {
+            $result = $helper->$function(...$params);
+        } else {
+            $result = $helper->$function($params);
+        }
+
+        return $result;
     }
 
     public function createHelper($helper, $config = array())

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -20,18 +20,15 @@ class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
             $snippet = $this->__snippets[$name];
 
             //Use the stream buffer to evaluate the partial
-            $str = "<?php \n return <<<SNIPPET\n$snippet\nSNIPPET;\n";
+            $str = "<?php \n echo <<<SNIPPET\n$snippet\nSNIPPET;\n";
 
-            $buffer = $this->getObject('filesystem.stream.factory')->createStream('koowa-buffer://temp', 'w+b');
-            $buffer->truncate(0);
-            $buffer->write($str);
-
-            extract($variables, EXTR_OVERWRITE);
-
-            $result = include $buffer->getPath();
+            $result = $this->getObject('template.engine.factory')
+                ->createEngine('php')
+                ->loadString($str)
+                ->render($variables);
 
             //Cleanup whitespace
-            $result = str_replace(array(' >', ' "'), array('>', '"'), $result);
+            //$result = str_replace(array(' >', ' "'), array('>', '"'), $result);
         }
 
         return $result;

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -1,0 +1,37 @@
+<?php
+
+class ExtensionTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
+{
+    private $__snippets = array();
+
+    public function define(string $name, string $snippet, $overwrite = false)
+    {
+        if(!isset($this->__snippets[$name]) || $overwrite) {
+            $this->__snippets[$name] = $snippet;
+        }
+    }
+
+    public function expand(string $name, array $variables = array())
+    {
+        $result = false;
+
+        if(isset($this->__snippets[$name]))
+        {
+            $snippet = $this->__snippets[$name];
+
+            //Use the stream buffer to evaluate the partial
+            $str = "<?php \n return <<<SNIPPET\n$snippet\nSNIPPET;\n";
+
+            $buffer = $this->getObject('filesystem.stream.factory')->createStream('koowa-buffer://temp', 'w+b');
+            $buffer->truncate(0);
+            $buffer->write($str);
+
+            extract($variables, EXTR_OVERWRITE);
+
+            $result = include $buffer->getPath();
+        }
+
+        return $result;
+    }
+}
+

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -51,6 +51,7 @@ class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
                 $result = str_replace($tag,  str_replace(array(' >', ' "'), array('>', '"'), $tag), $result);
             }
         }
+        else throw new RuntimeException('Snippet: '.$name.' does not exist');
 
         return $result;
     }

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -1,6 +1,6 @@
 <?php
 
-class ExtensionTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
+class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
 {
     private $__snippets = array();
 

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -4,11 +4,28 @@ class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
 {
     private $__snippets = array();
 
+    public function __invoke($name, $snippet)
+    {
+        if(is_string($snippet)) {
+            $result = $this->define($name, $snippet);
+        } else {
+            $result = $this->expand($name, $snippet);
+        }
+
+        return $result;
+    }
+
     public function define(string $name, string $snippet, $overwrite = false)
     {
-        if(!isset($this->__snippets[$name]) || $overwrite) {
+        $result = false;
+
+        if(!isset($this->__snippets[$name]) || $overwrite)
+        {
             $this->__snippets[$name] = $snippet;
+            $result = true;
         }
+
+        return $result;
     }
 
     public function expand(string $name, array $variables = array())

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -19,7 +19,7 @@ class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
         {
             $snippet = $this->__snippets[$name];
 
-            //Use the stream buffer to evaluate the partial
+            //Use the php template engine to evaluate
             $str = "<?php \n echo <<<SNIPPET\n$snippet\nSNIPPET;\n";
 
             $result = $this->getObject('template.engine.factory')
@@ -27,8 +27,12 @@ class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
                 ->loadString($str)
                 ->render($variables);
 
-            //Cleanup whitespace
-            //$result = str_replace(array(' >', ' "'), array('>', '"'), $result);
+            //Find single whitespace before " or before > in html tags and remove it
+            preg_match_all('#<\s*\w.*?>#', $result, $tags);
+
+            foreach($tags as $tag) {
+                $result = str_replace($tag,  str_replace(array(' >', ' "'), array('>', '"'), $tag), $result);
+            }
         }
 
         return $result;

--- a/code/site/components/com_pages/template/helper/snippet.php
+++ b/code/site/components/com_pages/template/helper/snippet.php
@@ -29,6 +29,9 @@ class ComPagesTemplateHelperSnippet extends ComPagesTemplateHelperAbstract
             extract($variables, EXTR_OVERWRITE);
 
             $result = include $buffer->getPath();
+
+            //Cleanup whitespace
+            $result = str_replace(array(' >', ' "'), array('>', '"'), $result);
         }
 
         return $result;


### PR DESCRIPTION
## Template snippets

This PR adds support for snippets. A snippet behaves just like a double-quoted string, without the double quotes. This means that quotes in a snippet do not need to be escaped, but the escape codes can still be used. Variables are expanded, but the same care must be taken when expressing complex variables as with strings.

Snippets are for example useful to allow html code generated by helpers to be overridable, for a template, this can provide added flexibility to helpers.

### Helper methods

The snippet helper exposes two methods

- `snippet.define`
- `snippet.expand`

For example 

1. To define the snippet

````php
<? $snippet = '
<a class="button" href="$url" $attributes>
    $icon<span>$label</span>
</a>'
?>

<? helper('snippet.define', 'button', $snippet) ?>
````

2. To expend the snippet

````php
<? helper('snippet.expand’, 'button', [
'url' => 'http://exampme.com'
'icon' => /path/to/icon
'label' => 'Press here'
'attributes' => attributes([…])
]); ?>
````

A snippet can also be defined and expanded by calling the helper directly. If the second argument being passed is a string it will be used to define the helper if it’s empty or an array it will be used to expend the helper.

For example

````
<? helper('snippet’, 'button', '…' ?> //define a snippet
<? helper('snippet.expand’, 'button', […]?> //expand a snippet
````

## Notes

- Trying to expand a snippet that hasn’t been defined yet will result in a `RuntimeException` being throw.

- Trying to define a snippet that has already been defined will return false. There is a third `overwrite` argument that you need to set to `true` example: `<? helper('snippet’, 'button', '…', true ?>`

- If [template caching](https://github.com/joomlatools/joomlatools-pages/wiki/Caching#2-template-caching) is enabled snippets will be cached too, further improving their performance. 