### PR TITLE
Enable/disable event subscribers

### DIFF
--- a/code/site/components/com_pages/dispatcher/behavior/routable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/routable.php
@@ -22,7 +22,13 @@ class ComPagesDispatcherBehaviorRoutable extends KControllerBehaviorAbstract
 
     public function getRoute()
     {
-        return clone $this->__route;
+        $result = null;
+
+        if(is_object($this->__route)) {
+            $result = clone $this->__route;
+        }
+
+        return $result;
     }
 
     protected function _beforeDispatch(KDispatcherContextInterface $context)

--- a/code/site/components/com_pages/event/subscriber/abstract.php
+++ b/code/site/components/com_pages/event/subscriber/abstract.php
@@ -9,6 +9,36 @@
 
 abstract class ComPagesEventSubscriberAbstract extends KEventSubscriberAbstract
 {
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'enable'  => true,
+        ));
 
+        parent::_initialize($config);
+    }
+
+    public function subscribe(KEventPublisherInterface $publisher)
+    {
+        $result = [];
+
+        if($this->isEnabled()) {
+            $result = parent::subscribe($publisher);
+        }
+
+        return $result;
+    }
+
+    public function unsubscribe(KEventPublisherInterface $publisher)
+    {
+        if($this->isEnabled()) {
+            parent::unsubscribe($publisher);
+        }
+    }
+
+    public function isEnabled()
+    {
+        return $this->getConfig()->enable;
+    }
 }
 

--- a/code/site/components/com_pages/event/subscriber/errorhandler.php
+++ b/code/site/components/com_pages/event/subscriber/errorhandler.php
@@ -12,7 +12,7 @@ class ComPagesEventSubscriberErrorhandler extends ComPagesEventSubscriberAbstrac
     protected function _initialize(KObjectConfig $config)
     {
         $config->append(array(
-            'debug' => JDEBUG,
+            'enabled' => JDEBUG,
         ));
 
         parent::_initialize($config);
@@ -20,7 +20,7 @@ class ComPagesEventSubscriberErrorhandler extends ComPagesEventSubscriberAbstrac
 
     public function onException(KEventException $event)
     {
-        if(!$this->isDebug() && $this->getObject('request')->getFormat() == 'html')
+        if($this->getObject('request')->getFormat() == 'html')
         {
             //Let pages handle errors even if pages is not the active component. This allows for a site wide
             //implementation of error pages through pages.
@@ -30,10 +30,5 @@ class ComPagesEventSubscriberErrorhandler extends ComPagesEventSubscriberAbstrac
         }
 
         return false;
-    }
-
-    public function isDebug()
-    {
-        return $this->getConfig()->debug;
     }
 }


### PR DESCRIPTION
This PR implements a new `enable` config option for event subscribers Event subscribers are enabled by default. If a subscriber is disabled it will not be subscribed to the event publisher. 