### PR TITLE
JSON html output is't filtered

### DIFF
--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -186,8 +186,12 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         $template = $this->getObject('com://site/pages.template.default');
 
         //Load and render the page
-        if($template->loadFile('page://pages/'.$path)) {
+        if($template->loadFile('page://pages/'.$path))
+        {
             $content = $template->render(KObjectConfig::unbox($template->getData()));
+
+            //Remove <ktml:*> filter tags
+            $content = preg_replace('#<ktml:*\s*([^>]*)>#siU', '', $content);
         }
 
         return $content;


### PR DESCRIPTION
This PR applies a hotfix to remove filter placeholder from the content. The solution a quick fix to the problem and chosen to to filter the content, instead leave this up to the consumer of the content.