### PR TITLE
Improve var_dump support for page objects

### DIFF
--- a/code/site/components/com_pages/model/entity/item.php
+++ b/code/site/components/com_pages/model/entity/item.php
@@ -79,7 +79,24 @@ class ComPagesModelEntityItem extends KModelEntityAbstract implements ComPagesMo
 
     public function __debugInfo()
     {
-        return $this->_data;
+        $properties = $this->toArray();
+
+        foreach($properties as $key => $property)
+        {
+            if(is_object($property))
+            {
+                if(method_exists($property, '__debugInfo')) {
+                    $properties[$key] = var_dump($property);
+                } elseif(method_exists($property, '__toString')) {
+                    $properties[$key] = (string) $property;
+                } else {
+                    $properties[$key] = get_class($property);
+                }
+            }
+        }
+
+        return $properties;
+
     }
 
     public function __call($method, $arguments)

--- a/code/site/components/com_pages/model/entity/item.php
+++ b/code/site/components/com_pages/model/entity/item.php
@@ -85,8 +85,15 @@ class ComPagesModelEntityItem extends KModelEntityAbstract implements ComPagesMo
         {
             if(is_object($property))
             {
-                if(method_exists($property, '__debugInfo')) {
-                    $properties[$key] = var_dump($property);
+                if(method_exists($property, '__debugInfo'))
+                {
+                    ob_start();
+                    var_dump($property);
+                    $debug_info = ob_get_contents();
+                    ob_end_clean();
+
+                    $properties[$key] = $debug_info;
+
                 } elseif(method_exists($property, '__toString')) {
                     $properties[$key] = (string) $property;
                 } else {

--- a/code/site/components/com_pages/model/entity/item.php
+++ b/code/site/components/com_pages/model/entity/item.php
@@ -96,8 +96,15 @@ class ComPagesModelEntityItem extends KModelEntityAbstract implements ComPagesMo
 
                 } elseif(method_exists($property, '__toString')) {
                     $properties[$key] = (string) $property;
-                } else {
-                    $properties[$key] = get_class($property);
+                }
+                else
+                {
+                    if($property instanceof KObjectInterface)
+                    {
+                        $identifier = (string) $property->getIdentifier();
+                        $properties[$key] = $identifier.' :: ('.  get_class($property) .')';
+                    }
+                    else $properties[$key] = get_class($property);
                 }
             }
         }


### PR DESCRIPTION
This PR improves var_dump() page objects. If a property is an object and it implements __debugInfo() call it, if it can be casted to a string cast it, if not return the class name only.