### PR TITLE
Improve xml data support

### DIFF
--- a/code/site/components/com_pages/object/config/xml.php
+++ b/code/site/components/com_pages/object/config/xml.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesObjectConfigXml extends KObjectConfigXml
+{
+    public function fromString($string, $object = true)
+    {
+        $data = array();
+
+        if(!empty($string))
+        {
+            $dom = new DOMDocument('1.0', 'UTF-8');
+            $dom->preserveWhiteSpace = false;
+
+            if($dom->loadXml($string) === false) {
+                throw new DomainException('Cannot parse XML string');
+            }
+
+            $data = $this->_domToArray($dom->documentElement);
+        }
+
+        return $object ? $this->merge($data) : $data;
+    }
+
+    protected function _domToArray(DomNode $node)
+    {
+        $result = array();
+
+        if ($node->hasAttributes())
+        {
+            $attributes = $node->attributes;
+            foreach ($attributes as $attribute) {
+                $result['@attributes'][$attribute->name] = $attribute->value;
+            }
+        }
+
+        if ($node->hasChildNodes())
+        {
+            $children = $node->childNodes;
+            if ($children->length == 1)
+            {
+                $child = $children->item(0);
+                if (in_array($child->nodeType, [XML_TEXT_NODE, XML_CDATA_SECTION_NODE]))
+                {
+                    $result['@value'] = $child->nodeValue;
+                    return count($result) == 1 ? $result['@value'] : $result;
+                }
+
+            }
+
+            $groups = array();
+            foreach ($children as $child)
+            {
+                if (isset($result[$child->nodeName]))
+                {
+                    if (!isset($groups[$child->nodeName]))
+                    {
+                        $result[$child->nodeName] = array($result[$child->nodeName]);
+                        $groups[$child->nodeName] = 1;
+                    }
+
+                    $result[$child->nodeName][] = $this->_domToArray($child);
+
+
+                }
+                else $result[$child->nodeName] = $this->_domToArray($child);
+            }
+        }
+        return $result;
+    }
+}

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -44,6 +44,7 @@ return [
                 'md'   => 'ComPagesObjectConfigMarkdown',
                 'csv'  => 'ComPagesObjectConfigCsv',
                 'json' => 'ComPagesObjectConfigJson',
+                'xml'  => 'ComPagesObjectConfigXml',
             ],
         ],
         'template.locator.factory' => [


### PR DESCRIPTION
This PR implements improvements to the data api to better support complex xml structures. 

### 1. XML parsing

The xml parser has been improved to handle node attributes. If an element has attributes the attributes are parsed into an `@attributes` array and the node value is parsed into a `@value` element

Example: `['@attrributes' => [], '@value' => '']`

### 2. Data API

#### get()

The `get()` method has been improved to allow to return an item by it's path. 

For example: `data('tree')->get('path/to/node);`

#### filter()

The `filter()` method has been improved to to accept an array as value. A new `strict` method
parameter defines if the value check should be strict or not, if strict the value needs to be identical, if not, the value needs to be present in the item.

For example: ` data('tree')->get('path/to/node')->filter('@attributes', ['attribute-name' => 'attribute-value']); `

#### find()

Added  a new `find()` method to recursively find items with a specific key. 

For example: `data('tree')->get('node);`

#### toString()

Made the  `toString()` method aware of xml parsed items. Return the value if @value key exists in the item.

For example: `<?= data('tree')->get('path/to/node);  ?>`