### PR TITLE
Add getParent() method to page entity

### DIFF
--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -9,6 +9,8 @@
 
 class ComPagesModelEntityPage extends ComPagesModelEntityItem
 {
+    private $__parent;
+
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
@@ -229,7 +231,16 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
 
     public function getParent()
     {
-        return $this->getObject('page.registry')->getPage($this->folder);
+        if(!$this->__parent)
+        {
+            $page = $this->getObject('page.registry')->getPage($this->folder);
+
+            $this->__parernt = $this->getObject($this->getIdentifier(),
+                array('data'  => $page->toArray())
+            );
+        }
+
+        return $this->__parent;
     }
 
     public function getContent()

--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -227,6 +227,11 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
         return isset($this->form) && $this->form !== false ? $this->form : false;
     }
 
+    public function getParent()
+    {
+        return $this->getObject('page.registry')->getPage($this->folder);
+    }
+
     public function getContent()
     {
         if(!$this->content) {


### PR DESCRIPTION
This PR adds a getParent() method to the page entity to easily retrieve the current page parent entity.