### PR TITLE
Data namespaces

### DIFF
--- a/code/site/components/com_pages/data/locator.php
+++ b/code/site/components/com_pages/data/locator.php
@@ -19,4 +19,27 @@ class ComPagesDataLocator extends KTemplateLocatorFile
 
         parent::_initialize($config);
     }
+
+    public function setBasePath($path)
+    {
+        $this->_base_path = rtrim($path, '/');
+        return $this;
+    }
+
+    public function locate($url)
+    {
+        $base_path = $this->getBasePath();
+
+        if(!isset($this->_locations[$base_path.'/'.$url]))
+        {
+            $info = array(
+                'url'   => $url,
+                'path'  => '',
+            );
+
+            $this->_locations[$base_path.'/'.$url] = $this->find($info);
+        }
+
+        return $this->_locations[$base_path.'/'.$url];
+    }
 }

--- a/code/site/components/com_pages/resources/config/site.php
+++ b/code/site/components/com_pages/resources/config/site.php
@@ -22,6 +22,7 @@ return [
             'redirects'   => isset($config['redirects']) ? array_flip($config['redirects']) : array(),
         ],
         'data.registry' => [
+            'namespaces' => $config['data_namespaces'] ?? array(),
             'cache'      => $config['data_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
             'cache_time' => $config['data_cache_time'] ?? 60*60*24, //1d
             'cache_path' => $config['data_cache_path'] ?? $base_path.'/cache/data',


### PR DESCRIPTION
This PR implements support for data namespaces and allow to load data from different pre-configured locations. 

Namespaces are defined through the new `data_namespaces` config option which is an associative array. Example:

````php
'data_namespaces' => [
    'global' => JPATH_ROOT . '/data'
],
````

Data can be loaded from a named location by prefixing the path with the name of the location as follows: `data([namespace]://[path/to/data])`

Example: `data(global://config)`

This PR also adds support for loading external files by absolute path. Similar to loading data through http. Syntax is `file://path/to/data.json`