### PR TITLE
Automatic page and data cache validation

### DIFF
--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -12,12 +12,13 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
     const PAGES_TREE = \RecursiveIteratorIterator::SELF_FIRST;
     const PAGES_ONLY = \RecursiveIteratorIterator::CHILD_FIRST;
 
-    private $__locator = null;
+    private $__locator   = null;
 
     private $__pages  = array();
     private $__data   = null;
     private $__collections = array();
     private $__redirects   = array();
+    private $__cache_keys  = array();
 
     public function __construct(KObjectConfig $config)
     {
@@ -40,9 +41,9 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
-            'cache'       => JDEBUG ? false : true,
-            'cache_path'  => $this->getObject('com://site/pages.config')->getSitePath('cache'),
-            'cache_time'  => 60*60*24, //1 day
+            'cache'         => JDEBUG ? false : true,
+            'cache_path'    => $this->getObject('com://site/pages.config')->getSitePath('cache'),
+            'cache_validation' => true,
             'collections' => array(),
             'redirects'   => array(),
         ]);
@@ -227,7 +228,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
     public function isPage($path)
     {
         if(!isset($this->__pages[$path])) {
-           $result = (bool) $this->getLocator()->locate('page://pages/'. $path);
+            $result = (bool) $this->getLocator()->locate('page://pages/'. $path);
         } else {
             $result = ($this->__pages[$path] === false) ? false : true;
         }
@@ -434,20 +435,28 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
             $result['redirects']   = array_flip($redirects);
 
             //Generate a checksum
-            $result['hash']  = hash('crc32b', serialize($result));
+            $result['hash'] = hash('crc32b', serialize($result));
+
+            //Calculate the key
+            if($this->getConfig()->cache && $this->getConfig()->cache_validation) {
+                $result['key'] = $this->getCacheKey($basedir);
+            }
 
             $this->storeCache($basedir, $result);
-
         }
         else
         {
             if (!$result = require($cache)) {
                 throw new RuntimeException(sprintf('The page registry "%s" cannot be loaded from cache.', $cache));
             }
+
+            //Check if the cache is still valid, if not refresh it
+            if($this->getConfig()->cache_validation && $result['key'] != $this->getCacheKey($basedir)) {
+                $this->loadCache($basedir, true);
+            }
         }
 
         return $result;
-
     }
 
     public function storeCache($file, $data)
@@ -495,15 +504,40 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
             $hash   = crc32($file.PHP_VERSION);
             $cache  = $this->getConfig()->cache_path.'/page_'.$hash.'.php';
             $result = is_file($cache) ? $cache : false;
-
-            if($result && file_exists($file))
-            {
-                if((filemtime($cache) < filemtime($file)) || ((time() - filemtime($cache)) > $this->getConfig()->cache_time)) {
-                    $result = false;
-                }
-            }
         }
 
         return $result;
+    }
+
+    public function getCacheKey($path)
+    {
+        if(!isset($this->__cache_keys[$path]))
+        {
+            $size = function($path) use(&$size)
+            {
+                $result = array();
+
+                if (is_dir($path))
+                {
+                    $files = array_diff(scandir($path), array('.', '..', '.DS_Store'));
+
+                    foreach ($files as $file)
+                    {
+                        if (is_dir($path.'/'.$file)) {
+                            $result[$file] =  $size($path .'/'.$file);
+                        } else {
+                            $result[$file] = sprintf('%u', filemtime($path .'/'.$file));
+                        }
+                    }
+                }
+                else $result[basename($path)] = sprintf('%u', filemtime($path));
+
+                return $result;
+            };
+
+            $this->__cache_keys[$path] =  hash('crc32b', serialize( $size($path)));
+        }
+
+        return $this->__cache_keys[$path];
     }
 }

--- a/code/site/components/com_pages/resources/config/site.php
+++ b/code/site/components/com_pages/resources/config/site.php
@@ -15,21 +15,22 @@ return [
             'schemes' =>  $config['aliases'] ?? array()
         ],
         'page.registry' => [
-            'cache'       => $config['page_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
-            'cache_time'  => $config['page_cache_time'] ?? 60*60*24, //1d
-            'cache_path'  => $config['page_cache_path'] ?? $base_path.'/cache/pages',
+            'cache'            => $config['page_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
+            'cache_path'       => $config['page_cache_path'] ?? $base_path.'/cache/pages',
+            'cache_validation' => $config['page_cache_validation'] ?? true,
             'collections' => $config['collections'] ?? array(),
             'redirects'   => isset($config['redirects']) ? array_flip($config['redirects']) : array(),
         ],
         'data.registry' => [
             'namespaces' => $config['data_namespaces'] ?? array(),
-            'cache'      => $config['data_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
-            'cache_time' => $config['data_cache_time'] ?? 60*60*24, //1d
-            'cache_path' => $config['data_cache_path'] ?? $base_path.'/cache/data',
+            'cache'            => $config['data_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
+            'cache_path'       => $config['data_cache_path'] ?? $base_path.'/cache/data',
+            'cache_validation' => $config['data_cache_validation'] ?? true,
         ],
         'template.engine.factory' => [
-            'cache'      => $config['template_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
-            'cache_path' => $config['template_cache_path'] ?? $base_path.'/cache/templates',
+            'cache'            => $config['template_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
+            'cache_path'       => $config['template_cache_path'] ?? $base_path.'/cache/templates',
+            'cache_validation' => $config['template_cache_validation'] ?? true,
         ],
         'com://site/pages.dispatcher.behavior.cacheable' => [
             'cache'             => $config['http_cache'] ??  false,


### PR DESCRIPTION
This PR implements an automatic cache validation mechanism for the page and data cache. If cache validation is enabled a cache key will be calculated based on the filemtime of each file which is validated each time the cache is loaded

- The  `page_cache_time` config option has been removed and replace it with a `page_cache_validation` config option. Default is TRUE.

- The  `data_cache_time` config option has been removed and replace it with a `data_cache_validation` config option. Default is TRUE.

Page and data caching can be enabled by default and will work seamlessly. (This was already the case for the template cache).
