### PR TITLE
Include any static html page

### DIFF
--- a/code/administrator/components/com_pages/pages.xml
+++ b/code/administrator/components/com_pages/pages.xml
@@ -21,6 +21,7 @@
         <folder>database</folder>
         <folder>dispatcher</folder>
         <folder>event</folder>
+        <folder>http</folder>
         <folder>model</folder>
         <folder>object</folder>
         <folder>page</folder>

--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -155,7 +155,6 @@ class ComPagesDataObject extends KObjectConfig implements JsonSerializable
             $result = $result[0];
         }
 
-
         return is_array($result) ? new self($result) : $result;
     }
 
@@ -165,22 +164,32 @@ class ComPagesDataObject extends KObjectConfig implements JsonSerializable
 
         if(is_array($data))
         {
-            if(!isset($data['@value']))
-            {
-                // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-                $data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-
-                if (JSON_ERROR_NONE !== json_last_error())
-                {
-                    throw new InvalidArgumentException(
-                        'Cannot encode data to JSON string: ' . json_last_error_msg()
-                    );
-                }
+            if(!isset($data['@value'])) {
+                $data = $this->toJson()->toString();
+            } else {
+                $data = $data['@value'];
             }
-            else $data = $data['@value'];
         }
 
         return $data;
+    }
+
+    public function toHtml()
+    {
+        $html = new ComPagesObjectConfigHtml($this);
+        return $html->toDom();
+    }
+
+    public function toXml()
+    {
+        $html = new ComPagesObjectConfigXml($this);
+        return $html->toDom();
+    }
+
+    public function toJson()
+    {
+        $html = new ComPagesObjectConfigJson($this);
+        return $html;
     }
 
     public function jsonSerialize()

--- a/code/site/components/com_pages/data/registry.php
+++ b/code/site/components/com_pages/data/registry.php
@@ -22,7 +22,7 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         $this->__locator = $this->getObject('com://site/pages.data.locator');
 
         //Set the namespaces
-        $this->__namespaces = $config->namespaces;
+        $this->__namespaces = KObjectConfig::unbox($config->namespaces);
     }
 
     protected function _initialize(KObjectConfig $config)
@@ -47,31 +47,56 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         return $this->__namespaces;
     }
 
-    public function getData($path, $object = true)
+    public function fromUrl($url)
     {
-        //Set the base path in the locator
-        if($namespace = parse_url($path, PHP_URL_SCHEME))
+        if (!isset($this->__data[$url]))
         {
-            $path = str_replace($namespace.'://', '', $path);
-            $base_path = $this->__namespaces[$namespace];
+            $data = $this->getObject('com://site/pages.http.client')->get($url);
+
+            $class = $this->getObject('manager')->getClass('com://site/pages.data.object');
+            $data = new $class($data);
+
+            $this->__data[$url] = $data;
         }
-        else $base_path = $this->getObject('com://site/pages.config')->getSitePath('data');
+        else $data = $this->__data[$url];
 
-        $this->getLocator()->setBasePath($base_path);
+        return $data;
+    }
 
-        //Load the data and cache it
-        $result = array();
+    public function fromPath($path)
+    {
         if(!isset($this->__data[$path]))
         {
-            $segments = explode('/', $path);
-            $root     = array_shift($segments);
-
-            //Load the cache and do not refresh it
-            $data = $this->loadCache($root, false);
-
-            foreach($segments as $segment)
+            //Find path and base_path
+            if ($namespace = parse_url($path, PHP_URL_SCHEME))
             {
-                if(!isset($data[$segment]))
+                $file_path = str_replace($namespace . '://', '', $path);
+                $base_path = $this->__namespaces[$namespace];
+            }
+            else
+            {
+                $file_path = $path;
+                $base_path = $this->getLocator()->getConfig()->base_path;
+            }
+
+            $this->getLocator()->setBasePath($base_path);
+
+            //Load the data and cache it
+            $segments  = explode('/', $file_path);
+            $root_path = array_shift($segments);
+            $key = crc32($base_path . $root_path);
+
+            if (!isset($this->__data[$key]))
+            {
+                $data = $this->loadCache($root_path, false);
+                $this->__data[$key] = $data;
+            }
+            else $data = $this->__data[$key];
+
+            //Find the specific data segment
+            foreach ($segments as $segment)
+            {
+                if (!isset($data[$segment]))
                 {
                     $data = array();
                     break;
@@ -79,58 +104,35 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
                 else $data = $data[$segment];
             }
 
-            //Create the data object
+            $class = $this->getObject('manager')->getClass('com://site/pages.data.object');
+            $data = new $class($data);
+
             $this->__data[$path] = $data;
         }
+        else $data = $this->__data[$path];
 
-        if($object)
-        {
-            $class = $this->getObject('manager')->getClass('com://site/pages.data.object');
-            $result = new $class($this->__data[$path]);
-        }
-        else $result = $this->__data[$path];
-
-        return $result;
+        return $data;
     }
 
     private function __fromPath($path)
     {
-        if(!parse_url($path, PHP_URL_SCHEME) == 'http')
-        {
-            //Locate the data file
-            if (!$file = $this->getLocator()->locate($path)) {
-                throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
-            }
-
-            if(is_dir($file)) {
-                $result = $this->__fromDirectory($file);
-            } else {
-                $result = $this->__fromFile($file);
-            }
+        //Locate the data file
+        if (!$file = $this->getLocator()->locate($path)) {
+            throw new InvalidArgumentException(sprintf('The data path "%s" does not exist.', $path));
         }
-        else $result =  $this->getObject('com://site/pages.http.client')->get($path);
+
+        if(is_dir($file)) {
+            $result = $this->__fromDirectory($file);
+        } else {
+            $result = $this->__fromFile($file);
+        }
 
         return $result;
     }
 
     private function __fromFile($file)
     {
-        //Get the data
-        $result = array();
-
-        $url = trim(fgets(fopen($file, 'r')));
-        if(strpos($url, '://') !== false && in_array(substr($url, 0, 4), ['file', 'http']))
-        {
-            if(strpos($url, 'file://') === 0) {
-                $result = $this->getObject('object.config.factory')->fromFile($url, false);
-            } else {
-                $result =  $this->getObject('com://site/pages.http.client')->get($url);
-            }
-
-        }
-        else $result = $this->getObject('object.config.factory')->fromFile($file, false);
-
-        return $result;
+        return $this->getObject('object.config.factory')->fromFile($file, false);
     }
 
     private function __fromDirectory($path)
@@ -202,20 +204,20 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
         return false;
     }
 
-    public function loadCache($basedir, $refresh = true)
+    public function loadCache($path, $refresh = true)
     {
-        $file = $this->getLocator()->getBasePath().'/'.$basedir;
+        $file = $this->getLocator()->getBasePath().'/'.$path;
 
         if ($refresh || !$cache = $this->isCached($file))
         {
-            $data = $this->__fromPath($basedir);
+            $data = $this->__fromPath($path);
 
             $result = array();
             $result['data'] = $data;
 
             //Calculate the key
             if($this->getConfig()->cache && $this->getConfig()->cache_validation) {
-                $result['key'] = $this->getCacheKey($basedir);
+                $result['key'] = $this->getCacheKey($path);
             }
 
             $this->storeCache($file, $result);
@@ -227,8 +229,8 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
             }
 
             //Check if the cache is still valid, if not refresh it
-            if($this->getConfig()->cache_validation && $result['key'] != $this->getCacheKey($basedir)) {
-                $this->loadCache($basedir, true);
+            if($this->getConfig()->cache_validation && $result['key'] != $this->getCacheKey($path)) {
+                $this->loadCache($path, true);
             }
 
             $data = $result['data'];
@@ -289,35 +291,35 @@ final class ComPagesDataRegistry extends KObject implements KObjectSingleton
 
     public function getCacheKey($path)
     {
+        $size = function($path) use(&$size)
+        {
+            $result = array();
+
+            if (is_dir($path))
+            {
+                $files = array_diff(scandir($path), array('.', '..', '.DS_Store'));
+
+                foreach ($files as $file)
+                {
+                    if (is_dir($path.'/'.$file)) {
+                        $result[$file] =  $size($path .'/'.$file);
+                    } else {
+                        $result[$file] = sprintf('%u', filesize($path .'/'.$file));
+                    }
+                }
+            }
+            else $result[basename($path)] = sprintf('%u', filesize($path));
+
+            return $result;
+        };
+
         if(!isset($this->__cache_keys[$path]))
         {
-            if($file = $this->getLocator()->locate($path))
-            {
-                $size = function($path) use(&$size)
-                {
-                    $result = array();
-
-                    if (is_dir($path))
-                    {
-                        $files = array_diff(scandir($path), array('.', '..', '.DS_Store'));
-
-                        foreach ($files as $file)
-                        {
-                            if (is_dir($path.'/'.$file)) {
-                                $result[$file] =  $size($path .'/'.$file);
-                            } else {
-                                $result[$file] = sprintf('%u', filemtime($path .'/'.$file));
-                            }
-                        }
-                    }
-                    else $result[basename($path)] = sprintf('%u', filemtime($path));
-
-                    return $result;
-                };
-
+            if($file = $this->getLocator()->locate($path)) {
                 $this->__cache_keys[$path] =  hash('crc32b', serialize( $size($file)));
+            }  else {
+                $this->__cache_keys[$path] = false;
             }
-            else $this->__cache_keys[$path] = false;
         }
 
         return $this->__cache_keys[$path];

--- a/code/site/components/com_pages/object/config/html.php
+++ b/code/site/components/com_pages/object/config/html.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesObjectConfigHtml extends ComPagesObjectConfigXml
+{
+    protected static $_format = 'text/html';
+
+    public function fromString($string, $object = true)
+    {
+        $data = array();
+
+        if(!empty($string))
+        {
+            $dom = new DOMDocumentHtml('1.0', 'UTF-8');
+            libxml_use_internal_errors(true);
+
+            $dom->normalizeDocument();
+            $dom->preserveWhiteSpace = false;
+
+            if($dom->loadHtml($string, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOBLANKS) === false) {
+                throw new DomainException('Cannot parse HTML string');
+            }
+
+            libxml_use_internal_errors(false);
+
+            $data = $this->_domToArray($dom);
+        }
+
+        return $object ? $this->merge($data) : $data;
+    }
+
+    public function toString()
+    {
+        return $this->toDom()->saveHTML();
+    }
+
+    public function toDom()
+    {
+        $data   = $this->toArray();
+
+        $dom = new DOMDocumentHtml('1.0', 'UTF-8');
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = true;
+
+        $this->_arrayToDom($dom, $dom, $data);
+
+        return $dom;
+    }
+}
+
+class DomDocumentHtml extends DOMDocument
+{
+    private $__xpath;
+
+    public function __toString() {
+        return parent::safeHTML();
+    }
+
+    public function query($expression)
+    {
+        if(!isset($this->__xpath)) {
+            $this->__xpath =  new DOMXPath($this);
+        }
+
+        return $this->__xpath->query($expression);
+    }
+
+    public function evaluate($expression)
+    {
+        if(!isset($this->__xpath)) {
+            $this->__xpath =  new DOMXPath($this);
+        }
+
+        return $this->__xpath->evaluate($expression);
+    }
+}

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -367,7 +367,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
 
                                             if(!empty($matches[0]))
                                             {
-                                                $data = $this->getObject('data.registry')->getData($matches[1]);
+                                                $data = $this->getObject('data.registry')->fromPath($matches[1]);
 
                                                 if($data && !empty($matches[2])) {
                                                     $data = $data->get($matches[2]);
@@ -511,30 +511,29 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
 
     public function getCacheKey($path)
     {
-        if(!isset($this->__cache_keys[$path]))
+        $size = function($path) use(&$size)
         {
-            $size = function($path) use(&$size)
+            $result = array();
+
+            if (is_dir($path))
             {
-                $result = array();
+                $files = array_diff(scandir($path), array('.', '..', '.DS_Store'));
 
-                if (is_dir($path))
+                foreach ($files as $file)
                 {
-                    $files = array_diff(scandir($path), array('.', '..', '.DS_Store'));
-
-                    foreach ($files as $file)
-                    {
-                        if (is_dir($path.'/'.$file)) {
-                            $result[$file] =  $size($path .'/'.$file);
-                        } else {
-                            $result[$file] = sprintf('%u', filemtime($path .'/'.$file));
-                        }
+                    if (is_dir($path.'/'.$file)) {
+                        $result[$file] =  $size($path .'/'.$file);
+                    } else {
+                        $result[$file] = sprintf('%u', filemtime($path .'/'.$file));
                     }
                 }
-                else $result[basename($path)] = sprintf('%u', filemtime($path));
+            }
+            else $result[basename($path)] = sprintf('%u', filemtime($path));
 
-                return $result;
-            };
+            return $result;
+        };
 
+        if(!isset($this->__cache_keys[$path])) {
             $this->__cache_keys[$path] =  hash('crc32b', serialize( $size($path)));
         }
 

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -45,6 +45,7 @@ return [
                 'csv'  => 'ComPagesObjectConfigCsv',
                 'json' => 'ComPagesObjectConfigJson',
                 'xml'  => 'ComPagesObjectConfigXml',
+                'html' => 'ComPagesObjectConfigHtml',
             ],
         ],
         'template.locator.factory' => [

--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -268,9 +268,9 @@ class ComPagesTemplateDefault extends KTemplate
                 foreach($path as $directory)
                 {
                     if (!$result instanceof ComPagesDataObject) {
-                        $result = $this->getObject('data.registry')->getData($directory);
+                        $result = $this->getObject('data.registry')->fromPath($directory);
                     } else {
-                        $result->append($this->getObject('data.registry')->getData($directory));
+                        $result->append($this->getObject('data.registry')->formPath($directory));
                     }
                 }
             }
@@ -281,7 +281,16 @@ class ComPagesTemplateDefault extends KTemplate
             }
 
         }
-        else $result = $this->getObject('data.registry')->getData($path);
+        else
+        {
+            $namespace = parse_url($path, PHP_URL_SCHEME);
+
+            if(!in_array($namespace, ['http', 'https'])) {
+                $result = $this->getObject('data.registry')->fromPath($path);
+            } else {
+                $result = $this->getObject('data.registry')->fromUrl($path);
+            }
+        }
 
         return $result;
     }


### PR DESCRIPTION
This PR adds support for html files to[ the data API](https://github.com/joomlatools/joomlatools-pages/wiki/Data). It adds two main improvements:

1. Loading data files by url
2. Loading and parsing html files

It's now possible to load any type of structured data file by file by url. For example: `data([url])`. If the file is a html or xml file it will be parsed to an array DomDocument, attributes, text and comment node are treated in a special way. (See also: https://github.com/joomlatools/joomlatools-pages/pull/248)

## New methods

Following new methods have been added to the data API to make it possible to cast a data object to a specific format, and in case of html or xml manipulate it using the Dom and/or XPath expressions before serialising it to string.

### toXml()

This method will return a `DomDocumentXml`. The object extends from [DomDocument
](https://www.php.net/manual/en/class.domdocument.php) and implement two additional methods:

- query() ([see DOMXPath::query()](https://www.php.net/manual/en/domxpath.query.php))
- evaluate()  ([see DOMXPath::evaluate()](https://www.php.net/manual/en/domxpath.evaluate.php))

Example: `$doc = data([path/to/data])->toXml()`

### toHtml()

This method will return a `DomDocumentHtml`. The object extends from [DomDocument
](https://www.php.net/manual/en/class.domdocument.php) and implement two additional methods:

- query() ([see DOMXPath::query()](https://www.php.net/manual/en/domxpath.query.php))
- evaluate()  ([see DOMXPath::evaluate()](https://www.php.net/manual/en/domxpath.evaluate.php))


Example: `$doc = data([path/to/data])->toHtml()`

#### toJson()

This method allow to cast the object to json. This is also the default behavior when a data object is serialised  to a string. 

Example: `data([path/to/data])->toJson()`

## Notes

- The alias support for url's has been removed. Instead load a data file by url by calling `data([url])`

- Data files that are loaded by url are not cached through the `data_cache`. They are cached using the `http_resource_cache`.

- The data runtime cache has been further improved for performance to prevent unneeded casting from array to object.

## Example

Follow example will extract the content from a published Google Doc and inject it in the page. The code uses the xpath query to clean up the html retrieved from Google, removing all class, id and style attributes.

````php
---
url: https://docs.google.com/document/d/e/2PACX-1vTK9nkPIsoq6ZJeVm86ns4BX7Q0bOcMHV5jYoaGlsREXUxt22kDW2zt0Zh3wSF9mquuVQKlPFyRw9HK/pub
---
<? $doc = data($url); ?>
<title><?= $doc->get('html/head/title') ?></title>
<?
$content = $doc->get('html/body/div')->filter('@attributes', ['id' => 'contents'])->remove('style')->toHtml();
foreach ($content->query('//*') as $node)
{
   foreach(['style', 'class', 'id'] as $attribute) {
      $node->removeAttribute($attribute);
   }
}
?>
<article>
   <?= $content; ?>
</article>
````

This will produce the following results

---  
![Screenshot 2020-01-16 at 03 54 12](https://user-images.githubusercontent.com/266640/72489328-00ac1380-3814-11ea-8314-d6ff00abe366.png)
