### PR TITLE
Issues with multi-site routing

### DIFF
--- a/code/site/components/com_pages/config.php
+++ b/code/site/components/com_pages/config.php
@@ -36,7 +36,8 @@ class ComPagesConfig extends KObject implements KObjectSingleton
 
     public function getSitePath($path = null)
     {
-        if($path)
+        //If the site path is empty do not try to return a path
+        if($this->_site_path && $path)
         {
             if(!$result = $this->_base_paths[$path]) {
                 $result = $this->_site_path.'/'.$path;

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -134,16 +134,22 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
 
     protected function _beforeDispatch(KDispatcherContextInterface $context)
     {
-        //Throw 404 if the page was not found
-        if(false !== $route = $this->getRoute())
-        {
-            //Set the query in the request
-            $context->request->setQuery($route->query);
-
-            //Set the page in the context
-            $context->page = $route->getPage();
+        //Throw 404 if the site was not found
+        if(false ===  $this->getObject('com://site/pages.config')->getSitePath()) {
+            throw new KHttpExceptionNotFound('Site Not Found');
         }
-        else throw new KHttpExceptionNotFound('Page Not Found');
+
+        //Throw 404 if the page was not found
+        if(false === $route = $this->getRoute()) {
+            throw new KHttpExceptionNotFound('Page Not Found');
+        }
+
+
+        //Set the query in the request
+        $context->request->setQuery($route->query);
+
+        //Set the page in the context
+        $context->page = $route->getPage();
 
         //Throw 415 if the media type is not allowed
         $format = strtolower($context->request->getFormat());

--- a/code/site/components/com_pages/dispatcher/router/resolver/regex.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/regex.php
@@ -144,9 +144,6 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
         //Check if we have a static route
         if(!isset($this->__static_routes[$path]))
         {
-            //Sort routes longest path to shortest
-            arsort($this->__dynamic_routes);
-
             //Match against the dynamic routes
             foreach($this->__dynamic_routes as $regex => $target)
             {

--- a/code/site/components/com_pages/event/subscriber/bootstrapper.php
+++ b/code/site/components/com_pages/event/subscriber/bootstrapper.php
@@ -25,21 +25,21 @@ class ComPagesEventSubscriberBootstrapper extends ComPagesEventSubscriberAbstrac
         $request = $this->getObject('request');
         $router  = $this->getObject('com://site/pages.dispatcher.router.site', ['request' => $request]);
 
-        if(false === $route = $router->resolve()) {
-            throw new KHttpExceptionNotFound('Site Not Found');
+        if(false !== $route = $router->resolve())
+        {
+            //Set the site path in the config
+            $config = $this->getObject('com://site/pages.config', ['site_path' => $route->getPath()]);
+
+            //Load the configuration
+            $this->_config = $this->_loadConfig($config->getSitePath());
+
+            //Bootstrap the site configuration
+            $this->_bootstrapSite($config->getSitePath(), $this->_config);
+
+            //Bootstrap the extensions
+            $this->_bootstrapExtensions($config->getSitePath('extensions'), $this->_config);
         }
-
-        //Set the site path in the config
-        $config = $this->getObject('com://site/pages.config', ['site_path' => $route->getPath()]);
-
-        //Load the configuration
-        $this->_config = $this->_loadConfig($config->getSitePath());
-
-        //Bootstrap the site configuration
-        $this->_bootstrapSite($config->getSitePath(), $this->_config);
-
-        //Bootstrap the extensions
-        $this->_bootstrapExtensions($config->getSitePath('extensions'), $this->_config);
+        else $this->getObject('com://site/pages.config', ['site_path' => false]);
     }
 
     public function onBeforeDispatcherDispatch(KEventInterface $event)

--- a/code/site/components/com_pages/event/subscriber/dispatcher.php
+++ b/code/site/components/com_pages/event/subscriber/dispatcher.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesEventSubscriberDispatcher extends ComPagesEventSubscriberAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'priority' => KEvent::PRIORITY_HIGH
+        ));
+
+        parent::_initialize($config);
+    }
+
+    public function onAfterApplicationRoute(KEventInterface $event)
+    {
+        $site_path  =  $this->getObject('com://site/pages.config')->getSitePath();
+        $page_route = $route = $this->getObject('com://site/pages.dispatcher.http')->getRoute();
+
+        if($page_route && $site_path)
+        {
+            $page = trim($page_route->getPath(false), '/');
+
+            $decorate = $this->getObject('page.registry')
+                ->getPage($page)
+                ->process->get('decorate', false);
+
+            if($decorate === false) {
+                $event->getTarget()->input->set('option', 'com_pages');
+            }
+        }
+    }
+}

--- a/code/site/components/com_pages/event/subscriber/pagedecorator.php
+++ b/code/site/components/com_pages/event/subscriber/pagedecorator.php
@@ -24,9 +24,12 @@ class ComPagesEventSubscriberPagedecorator extends ComPagesEventSubscriberAbstra
 
         if($menu->component !== 'com_pages')
         {
-            if($route = $this->getObject('com://site/pages.dispatcher.http')->getRoute())
+            $site_path  =  $this->getObject('com://site/pages.config')->getSitePath();
+            $page_route = $route = $this->getObject('com://site/pages.dispatcher.http')->getRoute();
+
+            if($page_route && $site_path)
             {
-                $page_route = $route->getPath(false);
+                $page_route = $page_route->getPath(false);
 
                 $base  = trim(dirname($menu->route), '.');
                 $route = trim(str_replace($base, '', $page_route), '/');
@@ -48,7 +51,7 @@ class ComPagesEventSubscriberPagedecorator extends ComPagesEventSubscriberAbstra
                 {
                     $decorate = $this->getObject('page.registry')
                         ->getPage($page)
-                        ->process->get('decorate', true);
+                        ->process->get('decorate', false);
 
                     if($decorate === true || (is_int($decorate) && ($decorate >= $level))) {
                         $this->_decoratePage($page, $event->getTarget());

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -62,9 +62,10 @@ return [
         ],
         'event.subscriber.factory' => [
             'subscribers' => [
+                'com://site/pages.event.subscriber.bootstrapper',
+                'com://site/pages.event.subscriber.dispatcher',
                 'com://site/pages.event.subscriber.pagedecorator',
                 'com://site/pages.event.subscriber.errorhandler',
-                'com://site/pages.event.subscriber.bootstrapper',
             ]
         ],
         'lib:template.engine.markdown' => [


### PR DESCRIPTION
This PR fixes issues with multi-site routing. 

### Additional changes

1. This PR removes the requirement for any menu items, pages will work without a menu item, a Pages menu item can still be used to create Joomla menu's but doesn't offer any additional functionality. 

2. This PR changes how the decorator works. [Decoration](https://github.com/joomlatools/joomlatools-pages/wiki/Decoration) now always needs to be enabled by setting `decorate` to `true`
