### PR TITLE
Template configuration support

### DIFF
--- a/code/site/components/com_pages/event/subscriber/bootstrapper.php
+++ b/code/site/components/com_pages/event/subscriber/bootstrapper.php
@@ -53,10 +53,13 @@ class ComPagesEventSubscriberBootstrapper extends ComPagesEventSubscriberAbstrac
                 $template = JFactory::getApplication()->getTemplate();
             }
 
-            if(isset($config['template_config']) && is_array($this->_config['template_config'])) {
-                $params = $this->_config['template_config'];
-            } else {
-                $params = null;
+            if(isset($config['template_config']) && is_array($this->_config['template_config']))
+            {
+                $params = JFactory::getApplication()->getTemplate(true)->params;
+
+                foreach($this->_config['template_config'] as $name => $value) {
+                    $params->set($name, $value);
+                }
             }
 
             JFactory::getApplication()->setTemplate($template, $params);

--- a/code/site/components/com_pages/event/subscriber/dispatcher.php
+++ b/code/site/components/com_pages/event/subscriber/dispatcher.php
@@ -23,16 +23,73 @@ class ComPagesEventSubscriberDispatcher extends ComPagesEventSubscriberAbstract
         $site_path  =  $this->getObject('com://site/pages.config')->getSitePath();
         $page_route = $route = $this->getObject('com://site/pages.dispatcher.http')->getRoute();
 
-        if($page_route && $site_path)
+        if($page_route !== false && $site_path !== false)
         {
-            $page = trim($page_route->getPath(false), '/');
+            $page = $page_route->getPage();
 
-            $decorate = $this->getObject('page.registry')
-                ->getPage($page)
-                ->process->get('decorate', false);
-
-            if($decorate === false) {
+            //Set the option
+            if($page->process->get('decorate', false) === false) {
                 $event->getTarget()->input->set('option', 'com_pages');
+            }
+
+            //Set the template
+            if($page->process->has('template'))
+            {
+                if($page->process->template->has('name')) {
+                    $template = $page->process->template->name;
+                } else {
+                    $template = JFactory::getApplication()->getTemplate();
+                }
+
+                $params = JFactory::getApplication()->getTemplate(true)->params;
+
+                if($page->process->template->has('config'))
+                {
+                    foreach($page->process->template->config as $name => $value) {
+                        $params->set($name, $value);
+                    }
+                }
+
+                JFactory::getApplication()->setTemplate($template, $params);
+            }
+        }
+    }
+
+    public function onAfterTemplateModules(KEventInterface $event)
+    {
+        if($route = $this->getObject('com://site/pages.dispatcher.http')->getRoute())
+        {
+            $page = $route->getPage();
+
+            if($page->process->has('template') && $page->process->template->has('modules'))
+            {
+                foreach($event->modules as $key => $module)
+                {
+                    $include = array();
+                    $exclude = array();
+
+                    foreach($page->process->template->get('modules') as $id)
+                    {
+                        if($id[0] == '-' || $id < 0) {
+                            $exclude[] = substr($id, 1);
+                        } else {
+                            $include[] = $id;
+                        }
+                    }
+
+                    if($include)
+                    {
+                        if (!in_array($module->title, $include) && !in_array($module->id, $include)) {
+                            unset($event->modules[$key]);
+                        }
+                    }
+                    else
+                    {
+                        if (in_array($module->title, $exclude) || in_array($module->id, $exclude)) {
+                            unset($event->modules[$key]);
+                        }
+                    }
+                }
             }
         }
     }

--- a/code/site/components/com_pages/event/subscriber/dispatcher.php
+++ b/code/site/components/com_pages/event/subscriber/dispatcher.php
@@ -57,39 +57,45 @@ class ComPagesEventSubscriberDispatcher extends ComPagesEventSubscriberAbstract
 
     public function onAfterTemplateModules(KEventInterface $event)
     {
-        if($route = $this->getObject('com://site/pages.dispatcher.http')->getRoute())
+        if($this->getObject('com://site/pages.dispatcher.http')->getRoute())
         {
-            $page = $route->getPage();
+            $page = $this->getObject('com://site/pages.dispatcher.http')->getRoute()->getPage();
 
             if($page->process->has('template') && $page->process->template->has('modules'))
             {
-                foreach($event->modules as $key => $module)
+                $modules = $page->process->template->modules;
+
+                if(count($modules))
                 {
-                    $include = array();
-                    $exclude = array();
+                    foreach ($event->modules as $key => $module)
+                    {
+                        $include = array();
+                        $exclude = array();
 
-                    foreach($page->process->template->get('modules') as $id)
-                    {
-                        if($id[0] == '-' || $id < 0) {
-                            $exclude[] = substr($id, 1);
-                        } else {
-                            $include[] = $id;
+                        foreach ($page->process->template->get('modules') as $id)
+                        {
+                            if ($id[0] == '-' || $id < 0) {
+                                $exclude[] = substr($id, 1);
+                            } else {
+                                $include[] = $id;
+                            }
                         }
-                    }
 
-                    if($include)
-                    {
-                        if (!in_array($module->title, $include) && !in_array($module->id, $include)) {
-                            unset($event->modules[$key]);
+                        if ($include)
+                        {
+                            if (!in_array($module->title, $include) && !in_array($module->id, $include)) {
+                                unset($event->modules[$key]);
+                            }
                         }
-                    }
-                    else
-                    {
-                        if (in_array($module->title, $exclude) || in_array($module->id, $exclude)) {
-                            unset($event->modules[$key]);
+                        else
+                        {
+                            if (in_array($module->title, $exclude) || in_array($module->id, $exclude)) {
+                                unset($event->modules[$key]);
+                            }
                         }
                     }
                 }
+                else $event->modules  = array();
             }
         }
     }


### PR DESCRIPTION
This PR requires: https://github.com/joomlatools/joomlatools-framework/pull/352

This PR adds support for per page Joomla template configuration. It adds a `template` config option to the process in the frontmatter.

````yaml
---
process:
    template:
        name: Beez3
        config:
            templatecolor: red
        modules: ["Main Menu", 17]
---
````

### Template config options

- `name`: Defines the name of the template to use
- `config`: Defines an associative array of template config overrides
- `modules`: Defines a list of modules to include, either by name or by id.

#### Including modules

By default modules are limited to the list provided. This allows to ensure no other modules then those listed can be present on the page. If the list is empty no modules will be included in the page. 

Example: `modules: ["Main Menu", 17]`

#### Excluding modules

If the module name or module id is prepended with a '-' the module will be excluded instead. This allows any module expect the ones listed to be present on the page.

Example: `modules: ["-Main Menu", -17]`
