### PR TITLE
Allow to extend a collection

### DIFF
--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -69,6 +69,28 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
         {
             $result = new KObjectConfig($this->__collections[$name]);
 
+            //If the collections extends another collection merge it
+            if(isset($result->extend))
+            {
+                $extend = $this->getCollection($result->extend);
+
+                //Merge state
+                if($extend->has('state')) {
+                    $extend->state->merge($result->get('state', array()));
+                } else {
+                    $extend->state = $result->get('state');
+                }
+
+                //Merge page
+                if($extend->has('page')) {
+                    $extend->page->merge($result->get('page', array()));
+                } else {
+                    $extend->page = $result->get('page');
+                }
+
+                $result = $extend;
+            }
+
             if(!isset($result->model)) {
                 $result->model = 'com://site/pages.model.pages';
             }


### PR DESCRIPTION
This PR adds an 'extend' option to the collection frontmatter and allows to extend another collection. For example, in case we have following collection defined on the page /pages/blog.html.php

````yaml
---
collection:
    state:
        folder: blog
        limit: 10
        sort: date
        order: desc
        collection: false
    page:
        layout: blog/post
        metadata:
            'og:type': article
---
````

We can extend it as follows to only return the pages tagged with `foo` and `bar` 

````yaml
---
collection:
    extend: blog
    state:
         limit: 4
         filter: 'tags in foo and tags in bar'
---
````