### PR TITLE
Add support for og:locale metadata tag

### DIFF
--- a/code/site/components/com_pages/model/entity/page.php
+++ b/code/site/components/com_pages/model/entity/page.php
@@ -133,6 +133,10 @@ class ComPagesModelEntityPage extends ComPagesModelEntityItem
             if($this->summary) {
                 $metadata->set('og:description', $this->summary);
             }
+
+            if($this->language) {
+                $metadata->set('og:locale', $this->language);
+            }
         }
         else
         {


### PR DESCRIPTION
This PR adds support for the Opengraph locale metadata tag. If the page language property is not empty it will be set as the og:locale metadata tag