### PR TITLE
Add config() template function

### DIFF
--- a/code/site/components/com_pages/resources/config/site.php
+++ b/code/site/components/com_pages/resources/config/site.php
@@ -9,44 +9,44 @@
 
 return [
 
-    'composer_path' => $config['composer_path'] ?? $base_path.'/vendor',
+    'composer_path' => $config['composer_path'],
     'identifiers'   => [
         'com://site/pages.template.filter.asset' => [
             'schemes' =>  $config['aliases'] ?? array()
         ],
         'page.registry' => [
-            'cache'            => $config['page_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
-            'cache_path'       => $config['page_cache_path'] ?? $base_path.'/cache/pages',
-            'cache_validation' => $config['page_cache_validation'] ?? true,
-            'collections' => $config['collections'] ?? array(),
-            'redirects'   => isset($config['redirects']) ? array_flip($config['redirects']) : array(),
-            'properties'  => $config['page'] ?? array(),
+            'cache'            => $config['page_cache'],
+            'cache_path'       => $config['page_cache_path'],
+            'cache_validation' => $config['page_cache_validation'],
+            'collections' => $config['collections'],
+            'redirects'   => array_flip($config['redirects']),
+            'properties'  => $config['page'],
         ],
         'data.registry' => [
-            'namespaces' => $config['data_namespaces'] ?? array(),
-            'cache'            => $config['data_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
-            'cache_path'       => $config['data_cache_path'] ?? $base_path.'/cache/data',
-            'cache_validation' => $config['data_cache_validation'] ?? true,
+            'namespaces'       => $config['data_namespaces'],
+            'cache'            => $config['data_cache'],
+            'cache_path'       => $config['data_cache_path'],
+            'cache_validation' => $config['data_cache_validation'],
         ],
         'template.engine.factory' => [
-            'cache'            => $config['template_cache'] ?? (bool) JFactory::getConfig()->get('caching'),
-            'cache_path'       => $config['template_cache_path'] ?? $base_path.'/cache/templates',
-            'cache_validation' => $config['template_cache_validation'] ?? true,
+            'cache'         => $config['template_cache'],
+            'cache_path'    => $config['template_cache_path'],
+            'cache_reload'  => $config['template_cache_validation'],
         ],
         'com://site/pages.dispatcher.behavior.cacheable' => [
-            'cache'             => $config['http_cache'] ??  false,
-            'cache_path'        => $config['http_cache_path'] ?? $base_path.'/cache/responses',
-            'cache_time'        => $config['http_cache_time']       ?? 60*15,  //15min
-            'cache_time_shared' => $config['http_cache_time_proxy'] ?? 60*60*2, //2h
-            'cache_validation'  => $config['http_cache_validation'] ?? true,
-            'cache_control'     => $config['http_cache_control'] ?? array(),
+            'cache'             => $config['http_cache'],
+            'cache_path'        => $config['http_cache_path'],
+            'cache_time'        => $config['http_cache_time'],
+            'cache_time_shared' => $config['http_cache_time_proxy'],
+            'cache_validation'  => $config['http_cache_validation'],
+            'cache_control'     => $config['http_cache_control'],
         ],
         'com://site/pages.http.client' => [
-            'cache'       => $config['http_resource_cache'] ??  (bool) JFactory::getConfig()->get('caching'),
-            'cache_time'  => $config['http_resource_cache_time'] ?? 60*60*24, //1d
-            'cache_path'  => $config['http_resource_cache_path'] ??  $base_path.'/cache/resources',
-            'cache_force' => $config['http_resource_cache_force'] ?? false,
-            'debug'       => $config['http_resource_cache_debug'] ?? (JDEBUG ? true : false),
+            'cache'       => $config['http_resource_cache'],
+            'cache_time'  => $config['http_resource_cache_time'],
+            'cache_path'  => $config['http_resource_cache_path'],
+            'cache_force' => $config['http_resource_cache_force'],
+            'debug'       => $config['http_resource_cache_debug'],
         ],
     ],
     'extensions' => $config['extensions'] ?? array(),

--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -34,6 +34,7 @@ class ComPagesTemplateDefault extends KTemplate
                 'data'       => [$this, '_fetchData'],
                 'slug'       => [$this, '_createSlug'],
                 'attributes' => [$this, '_createAttributes'],
+                'config'     => [$this, '_getConfig'],
             ],
             'cache'           => false,
             'cache_namespace' => 'pages',
@@ -293,5 +294,10 @@ class ComPagesTemplateDefault extends KTemplate
         }
 
         return $result;
+    }
+
+    protected function _getConfig($identifier = 'com://site/pages.config')
+    {
+        return clone $this->getObject($identifier)->getConfig();
     }
 }


### PR DESCRIPTION
This PR refactors the config handling and adds a `config()`template function which gives easy access to both the site runtime configuration as the configuration of extensions or other objects.

### 1. Access site configuration

````php
<?= config()->http_cache ?>
````
To access the site configuration simply call the config function with no arguments. 


### 2. Access object configuration

````php
<?= config('ext:template.helper.foo')->bar ?>
````

To access a specific objects its configuration you can call the config method with the object identifier. 