### PR TITLE
Automatically set new collection states

### DIFF
--- a/code/site/components/com_pages/model/collection.php
+++ b/code/site/components/com_pages/model/collection.php
@@ -47,6 +47,19 @@ abstract class ComPagesModelCollection extends KModelAbstract implements ComPage
         parent::_initialize($config);
     }
 
+    public function setState(array $values)
+    {
+        //Automatically create states that don't exist yet
+        foreach($values as $name => $value)
+        {
+            if(!$this->getState()->has($name)) {
+                $this->getState()->insert($name, 'string');
+            }
+        }
+
+        return parent::setState($values);
+    }
+
     final public function persist()
     {
         if(isset($this->_entity))

--- a/code/site/components/com_pages/model/database.php
+++ b/code/site/components/com_pages/model/database.php
@@ -47,8 +47,7 @@ class ComPagesModelDatabase extends ComPagesModelCollection
 
         if ($states = $this->getState()->getValues())
         {
-            $columns = array_intersect_key($states, $this->getTable()->getColumns());
-            $columns = $this->getTable()->mapColumns($columns);
+            $columns = $this->getTable()->filter($states);
 
             foreach ($columns as $column => $value)
             {
@@ -79,7 +78,7 @@ class ComPagesModelDatabase extends ComPagesModelCollection
                 if(is_string($this->__table) && strpos($this->__table, '.') !== false ) {
                     $this->__table = $this->getObject($this->__table);
                 } else {
-                    $this->__table = $this->getObject('com://site/pages.database.table.default', array('name' => $this->__table));
+                    $this->__table = $this->getObject('com://site/pages.database.table.'.$this->__table, array('name' => $this->__table));
                 }
             }
 

--- a/code/site/components/com_pages/model/filesystem.php
+++ b/code/site/components/com_pages/model/filesystem.php
@@ -49,19 +49,6 @@ class ComPagesModelFilesystem extends ComPagesModelCollection
         return bin2hex(random_bytes($this->_identity_key_length));
     }
 
-    public function setState(array $values)
-    {
-        //Automatically create states that don't exist yet
-        foreach($values as $name => $value)
-        {
-            if(!$this->getState()->has($name)) {
-                $this->getState()->insert($name, 'string');
-            }
-        }
-
-        return parent::setState($values);
-    }
-
     public function getHash()
     {
         $hahs = null;

--- a/code/site/components/com_pages/model/webservice.php
+++ b/code/site/components/com_pages/model/webservice.php
@@ -78,19 +78,6 @@ class ComPagesModelWebservice extends ComPagesModelCollection
         return $hash;
     }
 
-    public function setState(array $values)
-    {
-        //Automatically create states that don't exist yet
-        foreach($values as $name => $value)
-        {
-            if(!$this->getState()->has($name)) {
-                $this->getState()->insert($name, 'string');
-            }
-        }
-
-        return parent::setState($values);
-    }
-
     public function fetchData($count = false)
     {
         if(!isset($this->__data))


### PR DESCRIPTION
This PR moves the logic to define new states to the collection, and makes it available to database collections too. 

This allows to filter any collection, either by hardcoding a new state, or through a dynamic page route.  The state name needs to be the same as the database column name. 

For example. Let's consider following page, which is listing users and allows the result to be filtered by user group. 

````yaml
---
route: users/[digit:group_id]?
collection:
    model: database?table=users
---
````

The users database table has a `group_id` column that defines the group id as an integer.  We can now list all users as `http://example.com/users` or we can list all users of a specific group as `http://example.com/users/1`

If we do not want to make the state dynamic, but instead want to only show the users belonging to group `1`we could hardcode the state instead and do:

````yaml
---
route: users
collection:
    model: database?table=users
    state:
        group_id: 1
---
````






