### PR TITLE
Multiple filter constraints

### DIFF
--- a/code/site/components/com_pages/model/behavior/filterable.php
+++ b/code/site/components/com_pages/model/behavior/filterable.php
@@ -53,26 +53,30 @@ class ComPagesModelBehaviorFilterable extends ComPagesModelBehaviorQueryable
             }
             else
             {
-                foreach ($filters as $attribute => $value)
+                foreach ($filters as $attribute => $values)
                 {
-                    // Parse filter value for possible operator
-                    if (preg_match('#^([eq|neq|gt|gte|lt|lte|in|nin]+):(.+)\s*$#i', $value, $matches))
+                    //Support multiple constraints on the same attribute
+                    foreach((array) $values as $value)
                     {
-                        $this->_filters[] = [
-                            'attribute' => $attribute,
-                            'operation' => $matches[1],
-                            'values' => array_unique(explode(',', $matches[2])),
-                            'combination' => 'AND'
-                        ];
-                    }
-                    else
-                    {
-                        $this->_filters[] = [
-                            'attribute' => $attribute,
-                            'operation' => 'eq',
-                            'values' => array_unique(explode(',', $value)),
-                            'combination' => 'AND'
-                        ];
+                        // Parse filter value for possible operator
+                        if (preg_match('#^([eq|neq|gt|gte|lt|lte|in|nin]+):(.+)\s*$#i', $value, $matches))
+                        {
+                            $this->_filters[] = [
+                                'attribute' => $attribute,
+                                'operation' => $matches[1],
+                                'values' => array_unique(explode(',', $matches[2])),
+                                'combination' => 'AND'
+                            ];
+                        }
+                        else
+                        {
+                            $this->_filters[] = [
+                                'attribute' => $attribute,
+                                'operation' => 'eq',
+                                'values' => array_unique(explode(',', $value)),
+                                'combination' => 'AND'
+                            ];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR adds support for multiple filter constraints for the same attribute. For example:

Through frontmatter:

````yaml
---
collection:
    model: database?table=bar
    state:
         filter:
            foo:
                - 'gt:1'
                - 'lt:10'
---
````

Through url:

`http://example.com/bar?filter[id][]=gt:1&filter[id][]=lt:10`