### PR TITLE
Async Http Cache Proxy

### DIFF
--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -230,6 +230,16 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
         }
     }
 
+    protected function _actionSend(KDispatcherContextInterface $context)
+    {
+        //Do not send the response if it was already send
+        if(!headers_sent()) {
+            parent::_actionSend($context);
+        } else {
+            $this->terminate($context);
+        }
+    }
+
     protected function _renderError(KDispatcherContextInterface $context)
     {
         //Get the exception object


### PR DESCRIPTION
 This PR refactors the http cache proxy to support async cache validation.  Changes:

- The proxy now accepts and  anonymous function that will call the application. 
- The proxy no longer handles cache expiration, only etag based cache validation is supported. 

The proxy will return the resource from cache immediately if it exists and validate it async in the background. This ensure that each request is equally fast.

The proxy uses [fastcgi_finish_request();](https://www.php.net/manual/en/function.fastcgi-finish-request.php) to flush all response data to the client. 

Note: [PFM](https://www.php.net/manual/en/install.fpm.php) is required

#### Notes

- PROXY-REFRESHED and PROXY-HIT cache status codes have been removed