### PR TITLE
Add support for shuffle to database collection

### DIFF
--- a/code/site/components/com_pages/model/behavior/sortable.php
+++ b/code/site/components/com_pages/model/behavior/sortable.php
@@ -116,6 +116,10 @@ class ComPagesModelBehaviorSortable extends ComPagesModelBehaviorQueryable
             $query->order($column, $order);
         }
 
+        if($state->order && $state->order == 'shuffle') {
+            $query->shuffle();
+        }
+
         return $query;
     }
 }


### PR DESCRIPTION
Requires: https://github.com/joomlatools/joomlatools-framework/pull/363


This PR adds support for the `shuffle` ordering to the database collection. 

Through frontmatter

````yaml
---
collection:
    model: database?table=content
    state:
        order: shuffle
---
````

Through url

http://example.com/bar?order=shuffle