### PR TITLE
Add X-Robots-Tag header

### DIFF
--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -227,6 +227,11 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
             }
 
             $this->getResponse()->getHeaders()->set('Link', array($context->page->canonical => array('rel' => 'canonical')));
+
+            //Add X-Robots-Tag
+            if($context->page->metadata->has('robots')) {
+                $this->getResponse()->getHeaders()->set('X-Robots-Tag', KObjectConfig::unbox($context->page->metadata->robots));
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds the `X-Robots-Tag` header for `GET` or `HEAD` requests if robots metadata is specified for the page.

For more details on the robots meta tags see: https://developers.google.com/search/reference/robots_meta_tag