### PR TITLE
Cache collection

### DIFF
--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -88,7 +88,9 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
                     $this->storeCache($this->getCacheKey(), $cache);
 
                     //Terminate the request
-                    $response->send();
+                    if(!headers_sent()) {
+                        $response->send();
+                    }
                 }
                 else
                 {
@@ -135,11 +137,11 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
                 }
                 else
                 {
-                    $this->getConfig()->cache = false;
-                    $context->response->getHeaders()->set('Cache-Status', self::CACHE_DYNAMIC);
-                    $context->response->getHeaders()->set('Cache-Control', ['no-store']);
+                    $context->getResponse()->getHeaders()->set('Cache-Status', self::CACHE_DYNAMIC);
+                    $context->getResponse()->getHeaders()->set('Cache-Control', ['no-store']);
                 }
             }
+            else $context->getResponse()->getHeaders()->set('Cache-Control', ['no-store']);
         }
         else $context->getResponse()->getHeaders()->set('Cache-Status', self::CACHE_MISS);
 
@@ -148,20 +150,16 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
 
     protected function _beforeTerminate(KDispatcherContextInterface $context)
     {
-        $response = $this->getResponse();
-
         //Store the response in the cache
-        if($this->isCacheable() && $response->isCacheable() && !$response->isError()) {
+        if($this->isCacheable()) {
             $this->cache();
         }
     }
 
     public function onAfterApplicationRespond(KEventInterface $event)
     {
-        $response = $this->getResponse();
-
         //Proxy Joomla Output
-        if($this->isCacheable() && $response->isCacheable() && !$response->isError())
+        if($this->isCacheable())
         {
             $headers = array();
             foreach (headers_list() as $header)
@@ -170,8 +168,8 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
                 $headers[trim($parts[0])] = trim($parts[1]);
             }
 
-            $response->setHeaders($headers);
-            $response->setContent($event->getTarget()->getBody());
+            $this->getResponse()->setHeaders($headers);
+            $this->getResponse()->setContent($event->getTarget()->getBody());
 
             $this->cache();
         }
@@ -181,28 +179,41 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
     {
         $response = $context->getResponse();
 
-        if($content = $response->getContent())
+        if($response->isCacheable())
         {
-            //Remove blank empty lines
-            $content = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $content);
+            if($content = $response->getContent())
+            {
+                //Remove blank empty lines
+                $content = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $content);
 
-            //Get the page data
-            $page = [
-                'path'     => $this->getRoute()->getPage()->path,
-                'hash'     => $this->getRoute()->getPage()->hash,
-                'language' => $this->getRoute()->getPage()->language,
-            ];
+                //Get the page data
+                $page = [
+                    'path'     => $this->getRoute()->getPage()->path,
+                    'hash'     => $this->getRoute()->getPage()->hash,
+                    'language' => $this->getRoute()->getPage()->language,
+                ];
 
-            $data = array(
-                'url'         => rtrim((string) $context->getRequest()->getUrl(), '/'),
-                'page'        => $page,
-                'collections' => $this->getCollections(),
-                'status'      => $response->getStatusCode(),
-                'headers'     => $response->getHeaders()->toArray(),
-                'content'     => (string) $content,
-            );
+                $data = array(
+                    'url'         => rtrim((string) $context->getRequest()->getUrl(), '/'),
+                    'page'        => $page,
+                    'collections' => $this->getCollections(),
+                    'status'      => $response->getStatusCode(),
+                    'headers'     => $response->getHeaders()->toArray(),
+                    'content'     => (string) $content,
+                );
 
-            $this->storeCache($this->getCacheKey(), $data);
+                $this->storeCache($this->getCacheKey(), $data);
+            }
+        }
+        else
+        {
+            //In case cache exists delete it
+            $this->deleteCache($this->getCacheKey());
+
+            error_log( (string)(string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
+
+            //Set Cache-Control to no-store if response is not cacheable
+            $context->getResponse()->getHeaders()->set('Cache-Control', ['no-store']);
         }
     }
 
@@ -251,34 +262,25 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
 
     public function loadCache($key = null)
     {
-        static $cache;
-
         if(!$key) {
             $key = $this->getCacheKey();
         }
 
-        if(!isset($cache[$key]))
+        if($this->getConfig()->cache)
         {
-            if($this->getConfig()->cache)
+            $hash = crc32($key . PHP_VERSION);
+            $file = $this->getConfig()->cache_path . '/response_' . $hash . '.php';
+
+            if (is_file($file))
             {
-                $hash = crc32($key.PHP_VERSION);
-                $file = $this->getConfig()->cache_path.'/response_'.$hash.'.php';
+                $data = require $file;
 
-                if(is_file($file))
-                {
-                    $data = require $file;
-
-                    $data['content'] = $this->_prepareContent($data['content']);
-                    $data['headers'] = $this->_prepareHeaders($data['headers']);
-
-                    $cache[$key] = $data;
-                }
-                else $cache[$key] = false;
+                $data['content'] = $this->_prepareContent($data['content']);
+                $data['headers'] = $this->_prepareHeaders($data['headers']);
             }
-            else $cache[$key] = false;
         }
 
-        return $cache[$key];
+        return $data;
     }
 
     public function storeCache($key, $data)
@@ -315,6 +317,23 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
         }
 
         return false;
+    }
+
+    public function deleteCache($key = null)
+    {
+        if(!$key) {
+            $key = $this->getCacheKey();
+        }
+
+        if($this->getConfig()->cache)
+        {
+            $hash = crc32($key . PHP_VERSION);
+            $file = $this->getConfig()->cache_path . '/response_' . $hash . '.php';
+
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
     }
 
     public function isValid($page, $collections = array())

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -137,6 +137,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
                 {
                     $this->getConfig()->cache = false;
                     $context->response->getHeaders()->set('Cache-Status', self::CACHE_DYNAMIC);
+                    $context->response->getHeaders()->set('Cache-Control', ['no-store']);
                 }
             }
         }
@@ -187,11 +188,13 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
 
             //Get the page data
             $page = [
-                'path' => $this->getRoute()->getPage()->path,
-                'hash' => $this->getRoute()->getPage()->hash
+                'path'     => $this->getRoute()->getPage()->path,
+                'hash'     => $this->getRoute()->getPage()->hash,
+                'language' => $this->getRoute()->getPage()->language,
             ];
 
             $data = array(
+                'url'         => rtrim((string) $context->getRequest()->getUrl(), '/'),
                 'page'        => $page,
                 'collections' => $this->getCollections(),
                 'status'      => $response->getStatusCode(),

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -210,7 +210,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
             //In case cache exists delete it
             $this->deleteCache($this->getCacheKey());
 
-            error_log( (string)(string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
+            //error_log( (string)(string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
 
             //Set Cache-Control to no-store if response is not cacheable
             $context->getResponse()->getHeaders()->set('Cache-Control', ['no-store']);

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -213,7 +213,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
             //Set Cache-Control to no-store if response is not cacheable
             $context->getResponse()->getHeaders()->set('Cache-Control', ['no-store']);
 
-            //error_log( (string)(string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
+            //error_log((string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
         }
     }
 

--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -210,10 +210,10 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
             //In case cache exists delete it
             $this->deleteCache($this->getCacheKey());
 
-            //error_log( (string)(string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
-
             //Set Cache-Control to no-store if response is not cacheable
             $context->getResponse()->getHeaders()->set('Cache-Control', ['no-store']);
+
+            //error_log( (string)(string)$response->getRequest()->getUrl()."\n", 3, '/var/www/joomlatools/debug.txt');
         }
     }
 

--- a/code/site/components/com_pages/model/cache.php
+++ b/code/site/components/com_pages/model/cache.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesModelCache extends ComPagesModelCollection
+{
+    private $__data;
+
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append([
+            'type'         => 'cache',
+            'cache_path'   =>  $this->getObject('com://site/pages.config')->getSitePath('cache'),
+            'identity_key' => 'id',
+        ]);
+
+        parent::_initialize($config);
+    }
+
+    public function fetchData($count = false)
+    {
+        if(!isset($this->__data))
+        {
+            $this->__data = array();
+
+            foreach (glob($this->getConfig()->cache_path.'/response_*') as $file)
+            {
+                $data = require $file;
+
+                $this->__data[] = array(
+                    'id'        => crc32($data['url']),
+                    'url'       => $data['url'],
+                    'date'      => $data['headers']['Date'],
+                    'hash'      => $data['headers']['Etag'],
+                    'language'  => $data['page']['language'],
+                    'tags'      => array_unique(array_column($data['collections'], 'type')),
+                    'robots'    => isset($data['headers']['X-Robots-Tag']) ? array_map('trim', explode(',', $data['headers']['X-Robots-Tag'])) : array(),
+                );
+            }
+        }
+
+        return $this->__data;
+    }
+
+    public function getPrimaryKey()
+    {
+        //Cache doesn't have a primary key
+        return array();
+    }
+
+    protected function _actionReset(KModelContext $context)
+    {
+        $this->__data = null;
+
+        parent::_actionReset($context);
+    }
+}

--- a/code/site/components/com_pages/model/cache.php
+++ b/code/site/components/com_pages/model/cache.php
@@ -35,7 +35,7 @@ class ComPagesModelCache extends ComPagesModelCollection
                 $this->__data[] = array(
                     'id'        => str_replace('response_', '', basename($file, '.php')),
                     'url'       => $data['url'],
-                    'date'      => $data['headers']['Date'],
+                    'date'      => $this->getObject('date', array('date' => $data['headers']['Date'])),
                     'hash'      => $data['headers']['Etag'],
                     'language'  => $data['page']['language'],
                     'tags'      => array_unique(array_column($data['collections'], 'type')),

--- a/code/site/components/com_pages/model/cache.php
+++ b/code/site/components/com_pages/model/cache.php
@@ -33,7 +33,7 @@ class ComPagesModelCache extends ComPagesModelCollection
                 $data = require $file;
 
                 $this->__data[] = array(
-                    'id'        => crc32($data['url']),
+                    'id'        => str_replace('response_', '', basename($file, '.php')),
                     'url'       => $data['url'],
                     'date'      => $data['headers']['Date'],
                     'hash'      => $data['headers']['Etag'],

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -378,6 +378,11 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
                                         $page->date = filemtime($file);
                                     }
 
+                                    //Set the process
+                                    if (!$page->language) {
+                                        $page->language = 'en-GB';
+                                    }
+
                                     //Handle dynamic data
                                     array_walk_recursive ($page, function(&$value, $key)
                                     {

--- a/code/site/components/com_pages/resources/config/site.php
+++ b/code/site/components/com_pages/resources/config/site.php
@@ -48,6 +48,9 @@ return [
             'cache_force' => $config['http_resource_cache_force'],
             'debug'       => $config['http_resource_cache_debug'],
         ],
+        'com://site/pages.model.cache' => [
+            'cache_path' => $config['http_cache_path'],
+        ]
     ],
     'extensions' => $config['extensions'] ?? array(),
 ];

--- a/code/site/components/com_pages/view/json.php
+++ b/code/site/components/com_pages/view/json.php
@@ -196,11 +196,18 @@ class ComPagesViewJson extends KViewAbstract
     protected function _getEntityId(KModelEntityInterface $entity)
     {
         $values = array();
-        foreach($this->getModel()->getPrimaryKey() as $key){
-            $values[] = $entity->{$key};
-        }
 
-        return implode('/', $values);
+        if($keys = $this->getModel()->getPrimaryKey())
+        {
+            foreach($keys as $key){
+                $values[] = $entity->{$key};
+            }
+
+            $id = implode('/', $values);
+        }
+        else  $id = $entity->getProperty($entity->getIdentityKey(), '');
+
+        return $id;
     }
 
     /**
@@ -276,8 +283,11 @@ class ComPagesViewJson extends KViewAbstract
                 $query[$key] = $entity->{$key};
             }
 
-            $url = $this->getRoute($this->getModel()->getPage(), $query);
-            $links = ['self' => (string) $url];
+            if(!empty($query))
+            {
+                $url = $this->getRoute($this->getModel()->getPage(), $query);
+                $links = ['self' => (string) $url];
+            }
         }
 
         return $links;

--- a/code/site/components/com_pages/view/json.php
+++ b/code/site/components/com_pages/view/json.php
@@ -102,10 +102,29 @@ class ComPagesViewJson extends KViewAbstract
         {
             $context->parameters->total = $this->getModel()->count();
 
-            $page = $this->getModel()->getPage();
-
             foreach ($this->getModel()->fetch() as $entity) {
                 $document['data'][] = $this->_createResource($entity);
+            }
+
+            $page = $this->getModel()->getPage();
+
+            $document['meta'] = array();
+            $document['meta']['total'] = $this->getModel()->count();
+
+            if($title = $page->title) {
+                $document['meta']['title'] = $title;
+            }
+
+            if($description = $page->metadata->get('description')) {
+                $document['meta']['description'] = $description;
+            }
+
+            if($image = $page->image) {
+                $document['meta']['image'] = (string) $this->getUrl((string)$image);
+            }
+
+            if($language = $page->language) {
+                $document['meta']['language'] = $language;
             }
 
             if($this->getModel()->isPaginatable())
@@ -116,27 +135,8 @@ class ComPagesViewJson extends KViewAbstract
                 $limit  = (int) $paginator->limit;
                 $offset = (int) $paginator->offset;
 
-                $document['meta'] = [
-                    'offset'   => $offset,
-                    'limit'    => $limit,
-                    'total'	   => $total,
-                ];
-
-                if($title = $page->title) {
-                    $document['meta']['title'] = $title;
-                }
-
-                if($description = $page->metadata->get('description')) {
-                    $document['meta']['description'] = $description;
-                }
-
-                if($image = $page->image) {
-                    $document['meta']['image'] = (string) $this->getUrl((string)$image);
-                }
-
-                if($language = $page->language) {
-                    $document['meta']['language'] = $language;
-                }
+                $document['meta']['offset'] = $offset;
+                $document['meta']['limit']  = $limit;
 
                 if ($limit && $total > count($this->getModel()->fetch())) {
                     $document['links']['first'] = (string) $this->getRoute($route, array('offset' => 0));


### PR DESCRIPTION
This PR implements a cache collection which uses the http cache as data source. It can be used to expose the cache externally, for example to build an external cache (re)generator or can be used to build a sitemap.

Example: /cache.json

````yaml
---
collection:
    model: cache
    state:
        limit: 0
process:
    cache: false
metadata:
    robots: [noindex]
---
````

The cache collection exposes following data attributes:

- `id`:  The id of the cache, allows to lookup the actual file on the filesystem
-  `url`: The url that was used to generate the cache
- `date`: The data the cache was generated
-  `hash`: The hash
- `language`: The page language
 - `tags`: The page tags
 - `robots`: The page robots metadata

### Notes

The cache collection can also be used to build a sitemap, however is this case the sitemap will be based on the actual cached pages. This means the sitemap will be able to include routed pages, however it will only include pages that are cached already.

For example, following frontmatter creates a collection of all the cached pages, which are indexable. The sitemap will be refreshed every 2h (7200secs). 

````yaml
---
collection:
    model: cache
    state:
        limit: 0
        sort: date
       order: desc
       filter: 
           robots: "nin:noindex"
process:
    cache: 7200
metadata:
    robots: [noindex]
---
````
````xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

<? foreach(collection() as $page): ?>
    <url>
        <loc><?= $page->url ?></loc>
            <lastmod><?= $page->date->format(DateTime::ATOM); ?></lastmod>
    </url>
<? endforeach ?>
</urlset>
````