### PR TITLE
Do no return an array if we only found a single scalar result

### DIFF
--- a/code/site/components/com_pages/data/object.php
+++ b/code/site/components/com_pages/data/object.php
@@ -122,12 +122,14 @@ class ComPagesDataObject extends KObjectConfig implements JsonSerializable
             $data = array_values($data);
         }
 
-        //Do no return an array if we only found one result
-        if(count($data) == 1) {
+       //Do no return an array if we only found a single scalar result
+        if(count($data) == 1 && !is_array($data[0])) {
             $data = $data[0];
+        } else {
+            $data = new self($data);
         }
 
-        return is_array($data) ? new self($data) : $data;
+        return $data;
     }
 
     public function find($key)
@@ -150,12 +152,14 @@ class ComPagesDataObject extends KObjectConfig implements JsonSerializable
             $data = array_values($result);
         }
 
-        //Do no return an array if we only found one result
-        if(count($result) == 1) {
+        //Do no return an array if we only found a single scalar result
+        if(count($result) == 1 && !is_array($result[0])) {
             $result = $result[0];
+        } else {
+            $result = new self($result);
         }
 
-        return is_array($result) ? new self($result) : $result;
+        return $result;
     }
 
     public function toString()


### PR DESCRIPTION
This PR fixes an inconsistencies in the returned result of the `data::find()` and `data:filter()` methods. 