### PR TITLE
Add a default pages collection

### DIFF
--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -44,7 +44,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
             'cache'         => JDEBUG ? false : true,
             'cache_path'    => $this->getObject('com://site/pages.config')->getSitePath('cache'),
             'cache_validation' => true,
-            'collections' => array(),
+            'collections' => array('pages' => ['model' => 'com://site/pages.model.pages']),
             'redirects'   => array(),
             'properties'  => array(),
         ]);


### PR DESCRIPTION
This PR adds a default `pages` collection. To use:

### 1. In frontmatter

```yaml
---
collection:
    extend: pages
    state:
        folder: blog
        sort: date
        order: desc
---
````

### 2. In template

````php
<? $pages = collection('pages', ['folder' => 'blog', 'sort' => 'date', 'order' => 'desc']); ?>
````