### PR TITLE
Add support for multi-dimensional data to CSV form processor

### DIFF
--- a/code/site/components/com_pages/controller/processor/csv.php
+++ b/code/site/components/com_pages/controller/processor/csv.php
@@ -16,7 +16,7 @@ class ComPagesControllerProcessorCsv extends ComPagesControllerProcessorAbstract
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
-            'path'  => $this->getObject('com://site/pages.config')->getSitePath('logs'),
+            'path' => $this->getObject('com://site/pages.config')->getSitePath('logs'),
         ]);
 
         parent::_initialize($config);
@@ -24,28 +24,56 @@ class ComPagesControllerProcessorCsv extends ComPagesControllerProcessorAbstract
 
     public function getFile()
     {
-        return $this->getConfig()->path.'/'.$this->getChannel().'.csv';
+        return $this->getConfig()->path . '/' . $this->getChannel() . '.csv';
     }
 
     public function processData(array $data)
     {
         $file = $this->getFile();
 
+        $fields = array();
+        foreach ($data as $key => $value)
+        {
+            //Cast objects to string
+            if (is_object($value))
+            {
+                if (method_exists($value, '__toString')) {
+                    $value = (string)$value;
+                } else {
+                    $value = null;
+                }
+            }
+
+            //Implode array's
+            if (is_array($value))
+            {
+                if (is_numeric(key($value))) {
+                    $value = implode(',', $value);
+                } else {
+                    $value = json_encode($value);
+                }
+            }
+
+            $fields[$key] = $value;
+        }
+
         //Write the header
-        if(!file_exists($file) && !is_numeric(key($data))) {
-            $this->_writeCsvFile($file, array_keys($data));
+        if (!file_exists($file) && !is_numeric(key($fields))) {
+            $this->_writeCsvFile($file, array_keys($fields));
         }
 
         //Write the data
-        $this->_writeCsvFile($file, $data);
+        $this->_writeCsvFile($file, $fields);
     }
 
     protected function _writeCsvFile($file, $data)
     {
-        $fp = fopen($file, 'a');
+        if(!$fp = fopen($file, 'a')) {
+            throw new RuntimeException(sprintf('Could not open CSV file for writing: %s', $file));
+        }
 
         if(!fputcsv($fp, $data, static::DELIMITER, static::ENCLOSURE, static::ESCAPE_CHAR)) {
-            throw new RuntimeException('Could not write to CSV file:', $file);
+            throw new RuntimeException(sprintf('Could not write to CSV file: %s', $file));
         }
 
         fclose($fp);


### PR DESCRIPTION
Encode multi-dimensional data to comma seperated string or to json and unset objects that cannot be casted to string.