### PR TITLE
Add ComPagesCollection::getName() method

### DIFF
--- a/code/site/components/com_pages/model/collection.php
+++ b/code/site/components/com_pages/model/collection.php
@@ -10,6 +10,7 @@
 abstract class ComPagesModelCollection extends KModelAbstract implements ComPagesModelInterface, ComPagesModelFilterable
 {
     private $__type;
+    private $__name;
 
     public function __construct(KObjectConfig $config)
     {
@@ -27,13 +28,17 @@ abstract class ComPagesModelCollection extends KModelAbstract implements ComPage
 
         //Set the type
         $this->__type = $config->type;
+
+        //Set the name
+        $this->__name = $config->name;
     }
 
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
             'entity' => $this->getIdentifier()->getName(),
-            'type'             =>  '',
+            'type'             => '', //the collection type used when generating JSDNAPI
+            'name'             => '', //the collection name used to generate this model
             'identity_key'     => null,
             'behaviors'   => [
                 'com://site/pages.model.behavior.paginatable',
@@ -80,6 +85,11 @@ abstract class ComPagesModelCollection extends KModelAbstract implements ComPage
     public function getType()
     {
         return $this->__type;
+    }
+
+    public function getName()
+    {
+        return $this->__name;
     }
 
     public function getIdentityKey()

--- a/code/site/components/com_pages/model/factory.php
+++ b/code/site/components/com_pages/model/factory.php
@@ -45,6 +45,9 @@ class ComPagesModelFactory extends KObject implements KObjectSingleton
                 $identifier = $temp;
             }
 
+            //Set the name
+            $config['name'] = $name;
+
             //Set the type
             if($collection->has('type')) {
                 $config['type'] = $collection->type;


### PR DESCRIPTION
This method will return the name of the collection used to create the model and allows to specialise the model behavior targetting a specific collection.

Example:

````php
<?php
class ExtensionModelArticles extends ComPagesModelDatabase
{
    protected function _initialize(KObjectConfig $config)
    {
	$config->append(array(
		'table'  => 'content',
	));
	parent::_initialize($config);
    }
    
    public function fetchData($count = false)
    {
	$query = parent::fetchData($count = false);

	if($this->getName() == 'blog' && !$this->getObject('user')->isAuthentic())
	{
		$date = gmdate('Y-m-d H:i:s', strtotime('1 week ago'));
		$query->where('tbl.created < :date')->bind(['date' => $date]);
	}

	return $query;
    }
}
````