### PR TITLE
Allow to configure data root path for a webservice collection

### DIFF
--- a/code/site/components/com_pages/model/webservice.php
+++ b/code/site/components/com_pages/model/webservice.php
@@ -30,6 +30,7 @@ class ComPagesModelWebservice extends ComPagesModelCollection
             'client'       => 'http.client',
             'entity'       => 'resource',
             'url'          => '',
+            'data'         => '',
         ]);
 
         parent::_initialize($config);
@@ -97,6 +98,25 @@ class ComPagesModelWebservice extends ComPagesModelCollection
                     } else {
                         $this->__data = array();
                     }
+                }
+            }
+
+            if($path = $this->getConfig()->data)
+            {
+                if(is_string($path)) {
+                    $segments = explode('/', $path);
+                } else {
+                    $segments = KObjectConfig::unbox($path);
+                }
+
+                foreach($segments as $segment)
+                {
+                    if(!isset($this->__data[$segment]))
+                    {
+                        $this->__data = array();
+                        break;
+                    }
+                    else $this->__data = $this->__data[$segment];
                 }
             }
         }


### PR DESCRIPTION
This PR adds a new `data` config option to define the name or path fo the data element.  

### Verbose format

````yaml
---
collection:
    model: webservice
    config: 
       url: 'example.com?format=json&x=y'
       data: ['path', 'to', 'items']
---
````

_Note:_ the data can also be written as a string: `path/to/items`

### Simple format

````yaml
---
collection:
    model: webservice?url=example.com?format=json%26x=y&data=path%2Fto%2Fitems
---
````

_Note:_ when using the url notation the url and data value needs to be properly encoded: `& =>  %26` and `/ => %2F`

### A working example

Example to get data from the K2 demo site:

````php
---
collection:
    model: webservice?url=https://getk2.org/showcase?format=json&data=items
---

<ul>
    <? foreach(collection() as $item): ?>
        <li><?= $item->title ?></li>
    <? endforeach; ?>
</ul>
````