### PR TITLE
Division by zero error when limit is 0 

### DIFF
--- a/code/site/components/com_pages/dispatcher/router/resolver/pagination.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/pagination.php
@@ -83,7 +83,10 @@ class ComPagesDispatcherRouterResolverPagination extends ComPagesDispatcherRoute
 
             if (isset($state['limit']) && isset($page['offset']))
             {
-                $page['number'] = ceil($page['offset'] / $state['limit']) + 1;
+                if($state['limit']) {
+                    $page['number'] = ceil($page['offset'] / $state['limit']) + 1;
+                }
+
                 unset($page['offset']);
             }
 


### PR DESCRIPTION
This PR fixes the `Division by Zero error` when the `limit` is set to 0