### PR TITLE
Do not filter decorated component content

### DIFF
--- a/code/site/components/com_pages/event/subscriber/pagedecorator.php
+++ b/code/site/components/com_pages/event/subscriber/pagedecorator.php
@@ -67,6 +67,9 @@ class ComPagesEventSubscriberPagedecorator extends ComPagesEventSubscriberAbstra
 
         ob_start();
 
+        //Do not filter the content (but allow for LOW or LOWEST priority filters to still work)
+        $this->getConfig('com:koowa.template.filter.decorator')->priority = 4; //PRIORITY_LOW
+
         $dispatcher = $this->getObject('com://site/pages.dispatcher.http', ['controller' => 'decorator']);
 
         $dispatcher->getRequest()->getUrl()->setPath($page);


### PR DESCRIPTION
This PR changes the decorator filter to LOW priority to ensure it runs after the other template filters. By using LOW we still allow for any LOWEST priority filters to be run. 

Filtering the decorated component content can lead to unwanted side-effects when for example component specific inline `<script>`or `<style>` elements are being filtered and moved to the head. 
