### PR TITLE
Improve redirect routing

### DIFF
--- a/code/site/components/com_pages/controller/behavior/breadcrumbable.php
+++ b/code/site/components/com_pages/controller/behavior/breadcrumbable.php
@@ -27,7 +27,7 @@ class ComPagesControllerBehaviorBreadcrumbable extends KControllerBehaviorAbstra
                 {
                     $segments[] = $segment;
 
-                    if($route = $router->generate('pages:'.implode('/', $segments)))
+                    if($route = $router->generate('page:'.implode('/', $segments)))
                     {
                         $page = $route->getPage();
 

--- a/code/site/components/com_pages/dispatcher/behavior/redirectable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/redirectable.php
@@ -18,34 +18,6 @@ class ComPagesDispatcherBehaviorRedirectable extends KControllerBehaviorAbstract
         parent::_initialize($config);
     }
 
-    protected function _beforeDispatch(KDispatcherContextInterface $context)
-    {
-        $router = $this->getObject('com://site/pages.dispatcher.router.redirect', ['request' => $context->request]);
-
-        if(false !== $route = $router->resolve())
-        {
-            if($route->toString(KHttpUrl::AUTHORITY))
-            {
-                //External redierct: 301 permanent
-                $status = KHttpResponse::MOVED_PERMANENTLY;
-            }
-            else
-            {
-                //Internal redirect: 307 temporary
-                $status = KHttpResponse::TEMPORARY_REDIRECT;
-            }
-
-            //Qualify the route
-            $url = $router->qualify($route);
-
-            //Set the location header
-            $context->getResponse()->getHeaders()->set('Location',  $url);
-            $context->getResponse()->setStatus($status);
-
-            $context->getSubject()->send();
-        }
-    }
-
     protected function _beforeSend(KDispatcherContextInterface $context)
     {
         $response = $context->response;

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -72,7 +72,7 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
             $url  = urldecode($this->getRequest()->getUrl()->getPath());
             $path = trim(str_replace(array($base, '/index.php'), '', $url), '/');
 
-            $this->__route = $this->getRouter()->resolve('pages:'.$path,  $this->getRequest()->query->toArray());
+            $this->__route = $this->getRouter()->resolve('page:'.$path,  $this->getRequest()->query->toArray());
         }
 
         if(is_object($this->__route)) {

--- a/code/site/components/com_pages/dispatcher/router/pages.php
+++ b/code/site/components/com_pages/dispatcher/router/pages.php
@@ -27,7 +27,7 @@ class ComPagesDispatcherRouterPages extends ComPagesDispatcherRouterAbstract
     public function getRoute($route, array $parameters = array())
     {
         if($route instanceof ComPagesModelEntityPage) {
-            $route = 'pages:'.$route->path;
+            $route = 'page:'.$route->path;
         }
 
         return parent::getRoute($route, $parameters);

--- a/code/site/components/com_pages/dispatcher/router/redirect.php
+++ b/code/site/components/com_pages/dispatcher/router/redirect.php
@@ -24,14 +24,21 @@ class ComPagesDispatcherRouterRedirect extends ComPagesDispatcherRouterAbstract
 
     public function resolve($route = null, array $parameters = array())
     {
-        if(!$route)
+        $result = false;
+        if(count($this->getConfig()->routes))
         {
-            $base   = $this->getRequest()->getBasePath();
-            $url    = urldecode( $this->getRequest()->getUrl()->getPath());
+            if(!$route)
+            {
+                $base       = $this->getRequest()->getBasePath();
+                $url        = urldecode( $this->getRequest()->getUrl()->getPath());
+                $parameters = $this->getRequest()->getUrl()->getQuery(true);
 
-            $route  = trim(str_replace(array($base, '/index.php'), '', $url), '/');
+                $route  = trim(str_replace(array($base, '/index.php'), '', $url), '/');
+            }
+
+            $result = parent::resolve($route, $parameters);
         }
 
-        return parent::resolve($route, $parameters);
+        return $result;
     }
 }

--- a/code/site/components/com_pages/dispatcher/router/resolver/regex.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/regex.php
@@ -90,18 +90,21 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
      * Add a route for matching
      *
      * @param string $regex The route regex You can use multiple pre-set regex filters, like [digit:id]
-     * @param string $path The path this route should point to.
+     * @param string|callable $target The target this route points to
      * @return ComPagesDispatcherRouterResolverInterface
      */
-    public function addRoute($regex, $path)
+    public function addRoute($regex, $target)
     {
         $regex = trim($regex, '/');
-        $path  = rtrim($path, '/');
+
+        if(is_string($target)) {
+            $path = rtrim($target, '/');
+        }
 
         if(strpos($regex, '[') !== false) {
-            $this->__dynamic_routes[$regex] = $path;
+            $this->__dynamic_routes[$regex] = $target;
         } else {
-            $this->__static_routes[$regex] = $path;
+            $this->__static_routes[$regex] = $target;
         }
 
         return $this;
@@ -115,16 +118,8 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
      */
     public function addRoutes($routes)
     {
-        foreach((array)KObjectConfig::unbox($routes) as $path => $routes)
-        {
-            foreach((array) $routes as $regex)
-            {
-                if (is_numeric($path)) {
-                    $this->addRoute($regex, $regex);
-                } else {
-                    $this->addRoute($regex, $path);
-                }
-            }
+        foreach((array)KObjectConfig::unbox($routes) as $regex => $target) {
+            $this->addRoute($regex, $target);
         }
 
         return $this;
@@ -173,8 +168,13 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
             $this->__static_routes = array($path => $result) + $this->__static_routes;
         }
 
-        if($result !== false) {
-            $this->_buildRoute($result, $route);
+        if($result !== false)
+        {
+            if(is_callable($result)) {
+                $result = (bool) call_user_func($result, $route, false);
+            } else {
+                $result = $this->_buildRoute($result, $route);
+            }
         }
 
         return $result !== false ? parent::resolve($route) : false;
@@ -194,12 +194,20 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
         $path      = ltrim($route->getPath(), '/');
 
         //Dynamic routes
-        if($routes = array_keys($this->__dynamic_routes, $path))
+        $routes = $this->__dynamic_routes;
+
+        foreach($routes as $regex => $target)
         {
-            foreach($routes as $regex)
+            if(is_callable($target))
             {
-                //Generate the dynamic route
-                if($this->_buildRoute($regex, $route)) {
+                //Parse the route to match it
+                if($this->_parseRoute($regex, $route) && (bool) call_user_func($target, $route, false) == true) {
+                    $generated = true; break;
+                }
+            }
+            else
+            {
+                if($target == $path && $this->_buildRoute($regex, $route)) {
                     $generated = true; break;
                 }
             }
@@ -208,12 +216,22 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
         //Static routes
         if(!$generated)
         {
-            $routes = array_flip(array_reverse($this->__static_routes, true));
+            $routes = array_reverse($this->__static_routes, true);
 
-            if(isset($routes[$path]))
+            foreach($routes as $regex => $target)
             {
-                if($this->_buildRoute($routes[$path], $route)) {
-                    $generated = true;
+                if(is_callable($target))
+                {
+                    //Compare the path to match it
+                    if($regex == $path && (bool) call_user_func($target, $route, false) == true) {
+                        $generated = true; break;
+                    }
+                }
+                else
+                {
+                    if($target == $path && $this->_buildRoute($regex, $route)) {
+                        $generated = true; break;
+                    }
                 }
             }
         }
@@ -338,7 +356,7 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
                         if($optional) {
                             $regex = str_replace($pre . $block, '', $regex);
                         } else {
-                           $result = false; break;
+                            $result = false; break;
                         }
                     }
                 }

--- a/code/site/components/com_pages/dispatcher/router/resolver/regex.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/regex.php
@@ -170,8 +170,8 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
 
         if($result !== false)
         {
-            if(is_callable($result)) {
-                $result = (bool) call_user_func($result, $route, false);
+            if(isset($result['resolve']) && is_callable($result['resolve'])) {
+                $result = (bool) call_user_func($result['resolve'], $route);
             } else {
                 $result = $this->_buildRoute($result, $route);
             }
@@ -198,16 +198,17 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
 
         foreach($routes as $regex => $target)
         {
-            if(is_callable($target))
+            if(isset($target['generate']) && is_callable($target['generate']))
             {
                 //Parse the route to match it
-                if($this->_parseRoute($regex, $route) && (bool) call_user_func($target, $route, false) == true) {
+                if($this->_parseRoute($regex, $route) && (bool) call_user_func($target['generate'], $route) == true) {
                     $generated = true; break;
                 }
             }
             else
             {
-                if($target == $path && $this->_buildRoute($regex, $route)) {
+                //Parse the route to match it
+                if($this->_parseRoute($regex, $route) && $this->_buildRoute($target, $route)) {
                     $generated = true; break;
                 }
             }
@@ -220,15 +221,16 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
 
             foreach($routes as $regex => $target)
             {
-                if(is_callable($target))
+                if(isset($target['generate']) && is_callable($target['generate']))
                 {
                     //Compare the path to match it
-                    if($regex == $path && (bool) call_user_func($target, $route, false) == true) {
+                    if($regex == $path && (bool) call_user_func($target['generate'], $route) == true) {
                         $generated = true; break;
                     }
                 }
                 else
                 {
+                    //Compare the path to match it
                     if($target == $path && $this->_buildRoute($regex, $route)) {
                         $generated = true; break;
                     }

--- a/code/site/components/com_pages/dispatcher/router/router.php
+++ b/code/site/components/com_pages/dispatcher/router/router.php
@@ -30,6 +30,29 @@ class ComPagesDispatcherRouter extends ComPagesDispatcherRouterAbstract implemen
 
         //Add a global object alias
         $this->getObject('manager')->registerAlias($this->getIdentifier(), 'router');
+
+        $this->__routers = KObjectConfig::unbox($config->routers);
+    }
+
+    /**
+     * Initializes the options for the object
+     *
+     * Called from {@link __construct()} as a first step of object instantiation.
+     *
+     * @param   KObjectConfig $config    An optional ObjectConfig object with configuration options.
+     * @return 	void
+     */
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'routers' => [
+                'page'     => 'com://site/pages.dispatcher.router.pages',
+                'site'     => 'com://site/pages.dispatcher.router.site',
+                'redirect' => 'com://site/pages.dispatcher.router.redirect',
+            ],
+        ));
+
+        parent::_initialize($config);
     }
 
     /**
@@ -43,24 +66,38 @@ class ComPagesDispatcherRouter extends ComPagesDispatcherRouterAbstract implemen
      */
     public function resolve($route, array $parameters = array())
     {
-        $result = false;
+        $identifier = null;
 
-        //Find router package
+        //Find router identifier
         if($route instanceof KObjectInterface)
         {
-            if($route instanceof ComPagesDispatcherRouterRouteInterface) {
+            if($route instanceof ComPagesDispatcherRouterRouteInterface)
+            {
                 $package = $route->getScheme();
-            } else {
-                $package = $route->getIdentifier()->getPackage();
+
+                if(isset($this->__routers[$package])) {
+                    $identifier = $this->__routers[$package];
+                }
+            }
+            else $package = $route->getIdentifier()->getPackage();
+        }
+        else
+        {
+            $package = parse_url($route, PHP_URL_SCHEME);
+
+            if(isset($this->__routers[$package])) {
+                $identifier = $this->__routers[$package];
             }
         }
-        else $package = parse_url($route, PHP_URL_SCHEME);
+
+        //Identifier Fallback
+        if(!$identifier) {
+            $identifier = 'com://site/' . $package . '.dispatcher.router.' . $package;
+        }
 
         //Get router instance
-        if(!isset($this->__routers[$package]))
+        if(is_string($identifier))
         {
-            $identifier = 'com://site/'.$package.'.dispatcher.router.'.$package;
-
             $config = [
                 'request'   => $this->getRequest(),
                 'resolvers' => $this->getResolvers()
@@ -70,7 +107,7 @@ class ComPagesDispatcherRouter extends ComPagesDispatcherRouterAbstract implemen
 
             $this->__routers[$package] = $router;
         }
-        else $router = $this->__routers[$package];
+        else $router = $identifier;
 
         return $router->resolve($route, $parameters);
     }
@@ -86,24 +123,38 @@ class ComPagesDispatcherRouter extends ComPagesDispatcherRouterAbstract implemen
      */
     public function generate($route, array $parameters = array())
     {
-        $result = false;
+        $identifier = null;
 
-        //Find router package
+        //Find router identifier
         if($route instanceof KObjectInterface)
         {
-            if($route instanceof ComPagesDispatcherRouterRouteInterface) {
+            if($route instanceof ComPagesDispatcherRouterRouteInterface)
+            {
                 $package = $route->getScheme();
-            } else {
-                $package = $route->getIdentifier()->getPackage();
+
+                if(isset($this->__routers[$package])) {
+                    $identifier = $this->__routers[$package];
+                }
+            }
+            else $package = $route->getIdentifier()->getPackage();
+        }
+        else
+        {
+            $package = parse_url($route, PHP_URL_SCHEME);
+
+            if(isset($this->__routers[$package])) {
+                $identifier = $this->__routers[$package];
             }
         }
-        else $package = parse_url($route, PHP_URL_SCHEME);
+
+        //Identifier Fallback
+        if(!$identifier) {
+            $identifier = 'com://site/' . $package . '.dispatcher.router.' . $package;
+        }
 
         //Get router instance
-        if(!isset($this->__routers[$package]))
+        if(is_string($identifier))
         {
-            $identifier = 'com://site/'.$package.'.dispatcher.router.'.$package;
-
             $config = [
                 'request'   => $this->getRequest(),
                 'resolvers' => $this->getResolvers()
@@ -113,7 +164,7 @@ class ComPagesDispatcherRouter extends ComPagesDispatcherRouterAbstract implemen
 
             $this->__routers[$package] = $router;
         }
-        else $router = $this->__routers[$package];
+        else $router = $identifier;
 
         return $router->generate($route, $parameters);
     }

--- a/code/site/components/com_pages/event/subscriber/redirector.php
+++ b/code/site/components/com_pages/event/subscriber/redirector.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ComPagesEventSubscriberRedirector extends ComPagesEventSubscriberAbstract
+{
+    protected function _initialize(KObjectConfig $config)
+    {
+        $config->append(array(
+            'priority' => KEvent::PRIORITY_HIGH,
+        ));
+
+        parent::_initialize($config);
+    }
+
+    public function onAfterApplicationRoute(KEventInterface $event)
+    {
+        $request = $this->getObject('request');
+        $router  = $this->getObject('com://site/pages.dispatcher.router.redirect', ['request' => $request]);
+
+        if(false !== $route = $router->resolve())
+        {
+            if($route->toString(KHttpUrl::AUTHORITY))
+            {
+                //External redierct: 301 permanent
+                $status = KHttpResponse::MOVED_PERMANENTLY;
+            }
+            else
+            {
+                //Internal redirect: 307 temporary
+                $status = KHttpResponse::TEMPORARY_REDIRECT;
+            }
+
+            //Qualify the route
+            $url = $router->qualify($route);
+
+            //Set the location header
+            $dispatcher = $this->getObject('com://site/pages.dispatcher.http');
+            $dispatcher->getResponse()->getHeaders()->set('Location',  $url);
+            $dispatcher->getResponse()->setStatus($status);
+
+            $dispatcher->send();
+        }
+    }
+}

--- a/code/site/components/com_pages/page/registry.php
+++ b/code/site/components/com_pages/page/registry.php
@@ -239,10 +239,29 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
 
     public function getRoutes($path = null)
     {
-        if(!is_null($path)) {
-            $result = $this->__data['routes'][$path];
-        } else {
-            $result = $this->__data['routes'];
+        $result = array();
+        if(is_null($path))
+        {
+            foreach( $this->__data['routes'] as $path => $routes)
+            {
+                foreach((array) $routes as $regex)
+                {
+                    if (is_numeric($path)) {
+                        $result[$regex] = $regex;
+                    } else {
+                        $result[$regex] = $path;
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(isset($this->__data['routes'][$path]))
+            {
+                foreach((array) $this->__data['routes'][$path] as $regex) {
+                    $result[$regex] = $path;
+                }
+            }
         }
 
         return $result;
@@ -458,7 +477,7 @@ class ComPagesPageRegistry extends KObject implements KObjectSingleton
             $result['pages']       = $pages;
             $result['routes']      = $routes;
             $result['collections'] = $collections;
-            $result['redirects']   = array_flip($redirects);
+            $result['redirects']   = $redirects;
 
             //Generate a checksum
             $result['hash'] = hash('crc32b', serialize($result));

--- a/code/site/components/com_pages/resources/config/bootstrapper.php
+++ b/code/site/components/com_pages/resources/config/bootstrapper.php
@@ -63,6 +63,7 @@ return [
         'event.subscriber.factory' => [
             'subscribers' => [
                 'com://site/pages.event.subscriber.bootstrapper',
+                'com://site/pages.event.subscriber.redirector',
                 'com://site/pages.event.subscriber.dispatcher',
                 'com://site/pages.event.subscriber.pagedecorator',
                 'com://site/pages.event.subscriber.errorhandler',
@@ -82,7 +83,7 @@ return [
             }
         ],
         'com://site/pages.dispatcher.router.site' => [
-            'routes'  => isset($config['sites']) ? array_flip($config['sites']) : array(JPATH_ROOT.'/joomlatools-pages' => '[*]'),
+            'routes'  => isset($config['sites']) ? $config['sites'] : array('[*]' => JPATH_ROOT.'/joomlatools-pages'),
         ],
     ]
 ];

--- a/code/site/components/com_pages/resources/config/site.php
+++ b/code/site/components/com_pages/resources/config/site.php
@@ -19,7 +19,7 @@ return [
             'cache_path'       => $config['page_cache_path'],
             'cache_validation' => $config['page_cache_validation'],
             'collections' => $config['collections'],
-            'redirects'   => array_flip($config['redirects']),
+            'redirects'   => $config['redirects'],
             'properties'  => $config['page'],
         ],
         'data.registry' => [


### PR DESCRIPTION
This PR improves the redirect router. It adds support for  [callback](https://github.com/joomlatools/joomlatools-pages/pull/344) based routing alongside [pattern](https://github.com/joomlatools/joomlatools-pages/wiki/Routes) based routing which was implemented previously.

### Global redirects

The changes implemented as part of https://github.com/joomlatools/joomlatools-pages/pull/344  make it possible to implement redirects in Joomla outside of the context of Pages.

You do not need to setup a `/joomlatools-pages` folder to be able to define redirects.  If you just want to use this feature add a `configuration-pages.php` to your Joomla root, and defines your redirects.

````php
<?php
return array(
    '/articles/[:alias]' => '/blog/posts/[:alias],
    '/login'  => ['resolve' => function($route)
     {
	if(isset($route->query['view']) && $route->query['view'] == 'registration')
	{
		$route->path = '/register';
		unset($route->query['view']);

		return true;
	}
     }],
);
````

### Configure caching

You can configure the redirect cache lifetime through the `cache` query parameter in the route target. It will set the [`max-age` value for the Cache-Control header](https://tools.ietf.org/html/rfc7234#section-5.2.2.8) when the response is send.

> The max-age parameter indicates that the file is to be considered stale after its age is greater than the specified number of seconds.

> By setting a cache liftetime you instruct CDN's and browser cache the redirect for a specific time. This helps to increase the performance of your site and is recommended practice.

The cache parameters offers support for [English textual relative datetime formats](https://www.php.net/manual/en/datetime.formats.relative.php) as supported by [strtotime](https://www.php.net/manual/en/function.strtotime.php), for example:

- 1day
- 2hours
- 15min

See also: https://github.com/joomlatools/joomlatools-framework/pull/373

For example, set the cache lifetime to 1day

`>>    '/articles/[:alias]' => '/blog/posts/[:alias]/?cache=1day,` 