### PR TITLE
Extension bundles

### DIFF
--- a/code/site/components/com_pages/class/locator/extension.php
+++ b/code/site/components/com_pages/class/locator/extension.php
@@ -13,7 +13,7 @@ class ComPagesClassLocatorExtension extends KClassLocatorAbstract
 
     public function locate($classname, $basepath = null)
     {
-        if (substr($classname, 0, 9) === 'Extension')
+        if (substr($classname, 0, 3) === 'Ext')
         {
             $word  = strtolower(preg_replace('/(?<=\\w)([A-Z])/', ' \\1', $classname));
             $parts = explode(' ', $word);
@@ -41,10 +41,10 @@ class ComPagesClassLocatorExtension extends KClassLocatorAbstract
                 $path = implode('/', $parts) . '/';
             }
 
-            $result = $basepath.'/'.$package.'/'.$path . $file.'.php';
+            $result = $basepath.'/'.$path . $file.'.php';
 
             if(!is_file($result)) {
-                $result = $basepath.'/'.$package.'/'.$path . $file.'/'.$file.'.php';
+                $result = $basepath.'/'.$path . $file.'/'.$file.'.php';
             }
 
             return $result;

--- a/code/site/components/com_pages/event/subscriber/bootstrapper.php
+++ b/code/site/components/com_pages/event/subscriber/bootstrapper.php
@@ -106,13 +106,13 @@ class ComPagesEventSubscriberBootstrapper extends ComPagesEventSubscriberAbstrac
 
         //Register event subscribers
         foreach (glob($path.'/subscriber/[!_]*.php') as $filename) {
-            $this->getObject('event.subscriber.factory')->registerSubscriber('ext:subscriber.'.basename($filename, '.php'));
+            $this->getObject('event.subscriber.factory')->registerSubscriber('ext:pages.subscriber.'.basename($filename, '.php'));
         }
 
         //Register template filters
         $filters = array();
         foreach (glob($path.'/template/filter/[!_]*.php') as $filename) {
-            $filters[] = 'ext:template.filter.'.basename($filename, '.php');
+            $filters[] = 'ext:pages.template.filter.'.basename($filename, '.php');
         }
 
         if($filters) {

--- a/code/site/components/com_pages/event/subscriber/bootstrapper.php
+++ b/code/site/components/com_pages/event/subscriber/bootstrapper.php
@@ -97,36 +97,51 @@ class ComPagesEventSubscriberBootstrapper extends ComPagesEventSubscriberAbstrac
 
     protected function _bootstrapExtensions($path, $config = array())
     {
-        //Add extension locators
-        $this->getObject('manager')->getClassLoader()->registerLocator(new ComPagesClassLocatorExtension(array(
-            'namespaces' => array('\\'  => $path)
-        )));
+        $filters    = array();
+        $functions  = array();
+        $namespaces = array();
 
-        $this->getObject('manager')->registerLocator('com://site/pages.object.locator.extension');
+        foreach (glob($path.'/*', GLOB_ONLYDIR) as $directory)
+        {
+            $name = strtolower(basename($directory));
 
-        //Register event subscribers
-        foreach (glob($path.'/subscriber/[!_]*.php') as $filename) {
-            $this->getObject('event.subscriber.factory')->registerSubscriber('ext:pages.subscriber.'.basename($filename, '.php'));
+            //Register event subscribers
+            foreach (glob($directory.'/subscriber/[!_]*.php') as $filename) {
+                $this->getObject('event.subscriber.factory')->registerSubscriber('ext:'.$name.'.subscriber.'.basename($filename, '.php'));
+            }
+
+            //Find template filters
+            foreach (glob($directory.'/template/filter/[!_]*.php') as $filename) {
+                $filters[] = 'ext:'.$name.'.template.filter.'.basename($filename, '.php');
+            }
+
+            //Find template functions
+            foreach (glob($directory.'/template/function/[!_]*.php') as $filename) {
+                $functions[basename($filename, '.php')] = $filename;
+            }
+
+            //Store the namespace
+            $namespaces[ucfirst($name)] = $directory;
         }
 
-        //Register template filters
-        $filters = array();
-        foreach (glob($path.'/template/filter/[!_]*.php') as $filename) {
-            $filters[] = 'ext:pages.template.filter.'.basename($filename, '.php');
-        }
+        if($namespaces)
+        {
+            //Register template functions
+            if($functions) {
+                $this->getConfig('com://site/pages.template.default')->merge(['functions' => $functions]);
+            }
 
-        if($filters) {
-            $this->getConfig('com://site/pages.template.default')->merge(['filters' => $filters]);
-        }
+            //Register template filters
+            if($filters) {
+                $this->getConfig('com://site/pages.template.default')->merge(['filters' => $filters]);
+            }
 
-        //Register template functions
-        $functions = array();
-        foreach (glob($path.'/template/function/[!_]*.php') as $filename) {
-            $functions[basename($filename, '.php')] = $filename;
-        }
+            //Register extension namespaces
+            $this->getObject('manager')->getClassLoader()->registerLocator(new ComPagesClassLocatorExtension([
+                'namespaces' => $namespaces
+            ]));
 
-        if($functions) {
-            $this->getConfig('com://site/pages.template.default')->merge(['functions' => $functions]);
+            $this->getObject('manager')->registerLocator('com://site/pages.object.locator.extension');
         }
     }
 }

--- a/code/site/components/com_pages/object/locator/extension.php
+++ b/code/site/components/com_pages/object/locator/extension.php
@@ -15,7 +15,7 @@ class ComPagesObjectLocatorExtension extends KObjectLocatorAbstract
     {
         $config->append(array(
             'sequence' => array(
-                'Extension<Package><Class>',
+                'Ext<Package><Path><File>',
             )
         ));
 


### PR DESCRIPTION
This PR implements support for extension bundles and changes the extension identifier and classname scheme. Both now need to include the package. The type is now also `ext` for both.

- identifier: `ext:[package].[path].[file]`
- classname: `Ext[Package][Path][File]`

Extensions are now bundled inside their own package directory, format: `/joomlatools-pages/extensions/[package]`