### PR TITLE
Joomla content support

### DIFF
--- a/code/site/components/com_pages/resources/extensions/joomla/model/articles.php
+++ b/code/site/components/com_pages/resources/extensions/joomla/model/articles.php
@@ -1,0 +1,194 @@
+<?php
+class ExtJoomlaModelArticles extends ComPagesModelDatabase
+{
+	public function __construct(KObjectConfig $config)
+	{
+		parent::__construct($config);
+
+		$this->getState()
+			->insert('id'        , 'cmd', null, true)
+			->insert('category'  , 'cmd')
+			->insert('tags'      , 'cmd')
+
+			->insert('published' , 'bool')
+			->insert('archived'  , 'bool')
+			->insert('trashed'   , 'bool')
+			->insert('featured'  , 'bool')
+
+			->insert('author' , 'string')
+			->insert('editor' , 'string')
+			->insert('access' , 'cmd', array_unique($this->getObject('user')->getRoles()))
+		;
+	}
+
+	protected function _initialize(KObjectConfig $config)
+	{
+		$config->append(array(
+			'persistable' => false,
+			'type'   => 'articles',
+			'entity' => 'article',
+			'table'  => 'content',
+		));
+		parent::_initialize($config);
+	}
+
+	public function fetchData($count = false)
+	{
+		$state = $this->getState();
+
+		$query = $this->getObject('database.query.select')
+			->table(array('tbl' => $this->getTable()->getName()));
+
+		//#__tags
+		$query->columns([
+			'tags'	=> $this->getObject('database.query.select')
+				->table(array('t' => 'tags'))
+				->columns('GROUP_CONCAT(t.title)')
+				->join(['m' => 'contentitem_tag_map'], 'm.tag_id = t.id')
+				->where('m.content_item_id = tbl .id')
+		]);
+
+		//#__content
+		if(!$count)
+		{
+			$query->columns([
+				'id'       => 'tbl.id',
+				'title'    => 'tbl.title',
+				'slug'     => 'tbl.alias',
+				'summary'  => 'tbl.metadesc',
+				'content'  => 'CONCAT_WS("<!--more-->", tbl.introtext, IF(LENGTH(tbl.fulltext), tbl.fulltext ,NULL))',
+				'category' => 'tbl.catid',
+
+				'published' => 'IF(tbl.state = 1, 1, 0)',
+				'archived'  => 'IF(tbl.state = 2, 1, 0)',
+				'trashed'   => 'IF(tbl.state = -2, 1, 0)',
+				'featured'  => 'tbl.featured',
+
+				'author'      => 'tbl.created_by',
+				'editor'      => 'GREATEST(tbl.created_by, tbl.modified_by)',
+
+				'date'           => 'tbl.created',
+				'edited_date'    => 'GREATEST(tbl.created, tbl.modified)',
+				'published_date' => 'tbl.publish_up',
+				'archived_date'  => 'tbl.publish_down',
+
+				'image'       => 'tbl.images',
+				'links'       => 'tbl.urls',
+				'parameters'  => 'tbl.attribs',
+				'impressions' => 'tbl.hits',
+
+				//Protected properties (for getters)
+				'_metadata'   => 'tbl.metadata',
+			]);
+		}
+		else $query->columns('COUNT(*)');
+
+		//Joins
+		$query
+			->join(['c' => 'categories']         , 'tbl.catid = c.id')
+			->join(['g' => 'usergroups']         , 'tbl.access = g.id')
+			->join(['m' => 'contentitem_tag_map'], 'tbl.id = m.content_item_id')
+			->join(['t' => 'tags']				 , 't.id = m.tag_id');
+
+		if(!is_null($state->id))
+		{
+			if(is_string($state->id)) {
+				$articles = array_unique(explode(',',  $state->id));
+			} else {
+				$articles = (array) $state->id;
+			}
+
+			$query->where('(tbl.id IN :articles)')->bind(['articles' => $articles]);
+		}
+
+		if(!is_null($state->category))
+		{
+			if(is_string($state->category)) {
+				$categories = array_unique(explode(',',  $state->category));
+			} else {
+				$categories = (array) $state->category;
+			}
+
+			$query->where('(tbl.catid IN :category)')->bind(['category' => $categories]);
+		}
+
+		if(!is_null($state->tags))
+		{
+			if(is_string($state->tags)) {
+				$tags = array_unique(explode(',',  $state->tags));
+			} else {
+				$tags = (array) $state->tags;
+			}
+
+			$query->where('(t.title IN :tags)')->bind(['tags' => $tags]);
+		}
+
+		if(!is_null($state->author))
+		{
+			if(is_string($state->author)) {
+				$users = array_unique(explode(',',  $state->author));
+			} else {
+				$users = (array) $state->author;
+			}
+
+			$query->where('(tbl.created_by IN :authors)')->bind(['authors' => $users]);
+		}
+
+		if (!is_null($state->editor))
+		{
+			if(is_string($state->editor)) {
+				$users = array_unique(explode(',',  $state->editor));
+			} else {
+				$users = (array) $state->editor;
+			}
+
+			$query->where('(tbl.modified_by IN :editors)')->bind(['editors' => $users]);
+		}
+
+		if (!is_null($state->access))
+		{
+			if(is_string($state->access)) {
+				$access = array_unique(explode(',',  $state->access));
+			} else {
+				$access = (array) $state->access;
+			}
+
+			//If user doesn't have access to the category, he doesn't have access to the articles
+			$query->where('(tbl.access IN :access)')->bind(['access' => $access]);
+			$query->where('(c.access IN :access)')->bind(['access' => $access]);
+		}
+
+		if (!is_null($state->published))
+		{
+			if($state->published) {
+				$query->where('(tbl.state = 1)');
+			} else {
+				$query->where('(tbl.state = 0');
+			}
+		}
+
+		if (!is_null($state->archived))
+		{
+			if($state->archived) {
+				$query->where('(tbl.state = 2)');
+			} else {
+				$query->where('(tbl.state <> 2');
+			}
+		}
+
+		if (!is_null($state->trashed))
+		{
+			if($state->trashed) {
+				$query->where('(tbl.state = -2)');
+			} else {
+				$query->where('(tbl.state <> -2');
+			}
+		}
+
+		if (!is_null($state->featured)) {
+			$query->where('(tbl.featured = :featured)')->bind(['featured' => (bool) $state->featured]);
+		}
+
+		return $query;
+	}
+}

--- a/code/site/components/com_pages/resources/extensions/joomla/model/categories.php
+++ b/code/site/components/com_pages/resources/extensions/joomla/model/categories.php
@@ -1,0 +1,126 @@
+<?php
+class ExtJoomlaModelCategories extends ComPagesModelDatabase
+{
+	public function __construct(KObjectConfig $config)
+	{
+		parent::__construct($config);
+
+		$this->getState()
+			->insert('id'        , 'cmd', null, true)
+
+			->insert('published' , 'bool')
+
+			->insert('author' , 'string')
+			->insert('editor' , 'string')
+			->insert('access' , 'cmd', array_unique($this->getObject('user')->getRoles()))
+		;
+	}
+
+	protected function _initialize(KObjectConfig $config)
+	{
+		$config->append(array(
+			'persistable' => false,
+			'type'   => 'article_categories',
+			'entity' => 'category',
+			'table'  => 'categories',
+		));
+		parent::_initialize($config);
+	}
+
+	public function fetchData($count = false)
+	{
+		$state = $this->getState();
+
+		$query = $this->getObject('database.query.select')
+			->table(array('tbl' => $this->getTable()->getName()));
+
+		//#__content
+		if(!$count)
+		{
+			$query->columns([
+				'id'       => 'tbl.id',
+				'title'    => 'tbl.title',
+				'slug'     => 'tbl.alias',
+				'parent'   => 'IF(tbl.parent_id > 1, tbl.parent_id, NULL)',
+				'summary'  => 'tbl.metadesc',
+				'content'  => 'tbl.description',
+				'published' => 'tbl.published',
+
+				'author'      => 'tbl.created_user_id',
+				'editor'      => 'GREATEST(tbl.created_user_id, tbl.modified_user_id)',
+
+				'date'        => 'tbl.created_time',
+				'edited_date' => 'GREATEST(tbl.created_time, tbl.modified_time)',
+
+				'parameters'  => 'tbl.params',
+				'impressions' => 'tbl.hits',
+
+				//Protected properties (for getters)
+				'_metadata'   => 'tbl.metadata',
+			]);
+		}
+		else $query->columns('COUNT(*)');
+
+		//Joins
+		$query->join(['g' => 'usergroups'], 'tbl.access = g.id');
+
+		if(!is_null($state->id))
+		{
+			if(is_string($state->id)) {
+				$categories = array_unique(explode(',',  $state->id));
+			} else {
+				$categories = (array) $state->id;
+			}
+
+			$query->where('(tbl.id IN :categories)')->bind(['categories' => $categories]);
+		}
+
+		if(!is_null($state->author))
+		{
+			if(is_string($state->author)) {
+				$users = array_unique(explode(',',  $state->author));
+			} else {
+				$users = (array) $state->author;
+			}
+
+			$query->where('(tbl.created_user_id IN :authors)')->bind(['authors' => $users]);
+		}
+
+		if (!is_null($state->editor))
+		{
+			if(is_string($state->editor)) {
+				$users = array_unique(explode(',',  $state->editor));
+			} else {
+				$users = (array) $state->editor;
+			}
+
+			$query->where('(tbl.modified_user_id IN :editors)')->bind(['editors' => $users]);
+		}
+
+		if (!is_null($state->access))
+		{
+			if(is_string($state->access)) {
+				$access = array_unique(explode(',',  $state->access));
+			} else {
+				$access = (array) $state->access;
+			}
+
+			//If user doesn't have access to the category, he doesn't have access to the articles
+			$query->where('(tbl.access IN :access)')->bind(['access' => $access]);
+		}
+
+		if (!is_null($state->published))
+		{
+			if($state->published) {
+				$query->where('(tbl.published = 1)');
+			} else {
+				$query->where('(tbl.published = 0');
+			}
+		}
+
+		//Only fetch content categories
+		$query->where('tbl.extension = :component')->bind(['component' => 'com_content']);
+
+		return $query;
+	}
+}

--- a/code/site/components/com_pages/resources/extensions/joomla/model/entity/abstract.php
+++ b/code/site/components/com_pages/resources/extensions/joomla/model/entity/abstract.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+abstract class ExtJoomlaModelEntityAbstract extends ComPagesModelEntityItem
+{
+	protected function _initialize(KObjectConfig $config)
+	{
+		$config->append([
+			'data' => [
+				'id'		  => '',
+				'slug'        => '',
+				'name'        => '',
+				'title'       => '',
+				'summary'     => '',
+				'text'        => '',
+ 				'date'           => 'now',
+				'author'      => '',
+				'image'       => [
+					'url' 	   => '',
+					'alt'	   => '',
+					'caption'  => '',
+				],
+				'metadata'    => [
+					'og:type'        => 'website',
+					'og:title'       => null,
+					'og:url'         => null,
+					'og:image'       => null,
+					'og:description' => null,
+				],
+				'parameters'  => [],
+				'direction'   => 'auto',
+				'language'    => 'en-GB',
+			],
+			'internal_properties' => ['content', 'text', 'parameters'],
+			'base_path'           => $this->getObject('request')->getBasePath(),
+		]);
+
+		parent::_initialize($config);
+	}
+
+	public function get($property, $default = null)
+	{
+		if($this->hasProperty($property)) {
+			$result = $this->getProperty($property);
+		} else {
+			$result = $default;
+		}
+
+		return $result;
+	}
+
+	public function getPropertyName()
+	{
+		if(empty($name)) {
+			$name = ucwords(str_replace(array('_', '-'), ' ', $this->slug));
+		}
+
+		return $name;
+	}
+
+	public function getPropertyText()
+	{
+		return $this->getContent();
+	}
+
+	public function getPropertyMetadata()
+	{
+		//Get the raw metadata
+		$metadata = $this->_metadata;
+
+		if(is_string($metadata)) {
+			$metadata = array_filter((array) json_decode($metadata, true));
+		}
+
+		//Remove empty values
+		$metadata = new KObjectConfigJson($metadata);
+		$metadata->append($this->getConfig()->data->metadata);
+
+		if(!isset($metadata->description) && $this->summary) {
+			$metadata->set('description', $this->summary);
+		}
+
+		//Only set one image (give priority to the text image)
+		if($this->image && $this->image->url) {
+			$metadata->set('og:image', $this->image->url);
+		}
+
+		//Type and image are required. If they are not set remove any opengraph properties
+		if(!empty($metadata->get('og:type')) && $metadata->has('og:image'))
+		{
+			if($this->title) {
+				$metadata->set('og:title', $this->title);
+			}
+
+			if($this->summary) {
+				$metadata->set('og:description', $this->summary);
+			}
+
+			if($this->language) {
+				$metadata->set('og:locale', $this->language);
+			}
+		}
+		else
+		{
+			foreach($metadata as $name => $value)
+			{
+				if(strpos($name, 'og:') === 0 || strpos($name, 'twitter:') === 0) {
+					$metadata->remove($name);
+				}
+			}
+		}
+
+		return $metadata;
+	}
+
+	public function setPropertyDate($value)
+	{
+		if(is_integer($value)) {
+			$date = $this->getObject('date')->setTimestamp($value);
+		} else {
+			$date = $this->getObject('date', array('date' => trim($value)));
+		}
+
+		return $date;
+	}
+
+	public function setPropertyParameters($value)
+	{
+		return new KObjectConfigJson($value);
+	}
+
+	public function getBasePath()
+	{
+		return $this->getConfig()->base_path;
+	}
+
+	public function getAuthor()
+	{
+		$user = $this->getObject('user.provider')->load($this->author);
+		return $user;
+	}
+
+	public function getContent()
+	{
+		static $prepared;
+
+		//Prepare the content
+		if(!$prepared)
+		{
+			JPluginHelper::importPlugin('content');
+
+			$content = new stdClass;
+			$content->text = $this->content;
+			$params = (object) $this->parameters->toArray();
+			$name   = $this->getIdentifier()->getName();
+
+			JEventDispatcher::getInstance()->trigger(
+				'onContentPrepare',
+				['com_pages.'.$name, &$content, &$params, 0]
+			);
+
+			$this->content = $content->text;
+
+			$prepared = true;
+		}
+
+		return $this->content;
+	}
+
+	public function getContentType()
+	{
+		return 'text/html';
+	}
+
+	public function getHash()
+	{
+		return hash("crc32b", $this->getContent());
+	}
+
+	public function __toString()
+	{
+		return $this->getContent();
+	}
+}

--- a/code/site/components/com_pages/resources/extensions/joomla/model/entity/article.php
+++ b/code/site/components/com_pages/resources/extensions/joomla/model/entity/article.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ExtJoomlaModelEntityArticle extends ExtJoomlaModelEntityAbstract
+{
+	protected function _initialize(KObjectConfig $config)
+	{
+		$config->append([
+			'data' => [
+				'id'		  => '',
+				'slug'        => '',
+				'name'        => '',
+				'title'       => '',
+				'summary'     => '',
+				'excerpt'     => '',
+				'text'        => '',
+				'category'    => '',
+				'tags'        => '',
+ 				'date'           => 'now',
+				'edited_date'    => '',
+				'published_date' => '',
+				'archived_date'  => '',
+				'author'      => '',
+				'editor'      => '',
+				'image'       => [
+					'url' 	   => '',
+					'alt'	   => '',
+					'caption'  => '',
+				],
+				'metadata'    => [
+					'og:type'        => 'article',
+					'og:title'       => null,
+					'og:url'         => null,
+					'og:image'       => null,
+					'og:description' => null,
+
+					//http://ogp.me/ns/article
+					'article:published_time'  => null,
+					'article:modified_time'   => null,
+					'article:expiration_time' => null,
+					'article:tag'             => [],
+				],
+				'parameters'  => [],
+				'impressions' => 0,
+				'direction'   => 'auto',
+				'language'    => 'en-GB',
+			],
+			'internal_properties' => [ 'excerpt'],
+		]);
+
+		parent::_initialize($config);
+	}
+
+	public function getPropertyExcerpt()
+	{
+		$parts = preg_split('#<!--(.*)more(.*)-->#i', $this->getContent(), 2);
+
+		if(count($parts) > 1) {
+			$excerpt = $parts[0];
+		} else {
+			$excerpt = '';
+		}
+
+		return $excerpt;
+	}
+
+	public function getPropertyText()
+	{
+		$parts = preg_split('#<!--(.*)more(.*)-->#i', $this->getContent(), 2);
+
+		if(count($parts) > 1) {
+			$text = $parts[1];
+		} else {
+			$text = $parts[0];
+		}
+
+		return $text;
+	}
+
+	public function getPropertyMetadata()
+	{
+		$metadata = parent::getPropertyMetadata();
+
+		// Remove xreference
+		unset($metadata['xreference']);
+
+		if(!empty($this->published_date)) {
+			$metadata->set('article:published_time', (string) $this->published_date);
+		}
+
+		if(!empty($this->edited_date)) {
+			$metadata->set('article:modified_time', (string) $this->edited_date);
+		}
+
+		if(!empty($this->archived_date)) {
+			$metadata->set('article:expiration_time', (string) $this->archived_date);
+		}
+
+		if(count($this->tags)) {
+			$metadata->set('article:tag', implode(',', $this->tags->toArray()));
+		}
+
+		return $metadata;
+	}
+
+	public function getPropertyFields()
+	{
+		$fields = array();
+
+		$rows = $this->getObject('ext:joomla.model.fields')
+						->article($this->id)
+						->fetch();
+
+		foreach($rows as $row) {
+			$fields[] = $row;
+		}
+
+		return $fields;
+	}
+
+	public function setPropertyTags($value)
+	{
+		if($value)
+		{
+			if(is_string($value)) {
+				$value = explode(',', $value);
+			}
+		}
+		else $value = [];
+
+		return new KObjectConfigJson($value);
+	}
+
+	public function setPropertyCategory($value)
+	{
+		if($value)
+		{
+			//Get the single category
+			$value = $this->getObject('ext:joomla.model.categories')
+				->id($value)
+				->fetch()
+				->find($value);
+		}
+
+		return $value;
+	}
+
+	public function setPropertyEditedDate($value)
+	{
+		$date = null;
+
+		if($value && $value != '0000-00-00 00:00:00')
+		{
+			if(is_integer($value)) {
+				$date = $this->getObject('date')->setTimestamp($value);
+			} else {
+				$date = $this->getObject('date', array('date' => trim($value)));
+			}
+		}
+
+		return $date;
+	}
+
+	public function setPropertyPublishedDate($value)
+	{
+		$date = null;
+
+		if($value && $value != '0000-00-00 00:00:00')
+		{
+			if(is_integer($value)) {
+				$date = $this->getObject('date')->setTimestamp($value);
+			} else {
+				$date = $this->getObject('date', array('date' => trim($value)));
+			}
+		}
+
+		return $date;
+	}
+
+	public function setPropertyArchivedDate($value)
+	{
+		$date = null;
+
+		if($value && $value != '0000-00-00 00:00:00')
+		{
+			if(is_integer($value)) {
+				$date = $this->getObject('date')->setTimestamp($value);
+			} else {
+				$date = $this->getObject('date', array('date' => trim($value)));
+			}
+		}
+
+		return $date;
+	}
+
+	public function setPropertyImage($value)
+	{
+		if(is_string($value)) {
+			$value = json_decode($value, true);
+		}
+
+		//Normalize images
+		$image = array();
+
+		if($value['image_fulltext'])
+		{
+			$url = $value['image_fulltext'];
+
+			if(is_string($url) && strpos($url, '://') === false) {
+				$url = $this->getBasePath().'/'.ltrim($url, '/');
+			}
+
+			$url = $this->getObject('lib:http.url')->setUrl($url);
+
+			$image = [
+				'url'      => $url,
+				'alt'      => $value['image_fulltext_alt'] ?? '',
+				'caption'  => $value['image_fulltext_caption'] ?? '',
+			];
+		}
+		elseif($value['image_intro'])
+		{
+			$url = $value['image_intro'];
+
+			if(is_string($url) && strpos($url, '://') === false) {
+				$url =  $this->getBasePath().'/'.ltrim($url, '/');
+			}
+
+			$url = $this->getObject('lib:http.url')->setUrl($url);
+
+			$image = [
+				'url'      => $url,
+				'alt'      => $value['image_intro_alt'] ?? '',
+				'caption'  => $value['image_intro_caption'] ?? '',
+			];
+ 		}
+
+		return new KObjectConfigJson($image);
+	}
+
+	public function setPropertyLinks($value)
+	{
+		if(is_string($value)) {
+			$value = array_filter(json_decode($value, true));
+		}
+
+		$links = array();
+		foreach(['a', 'b', 'c'] as $name)
+		{
+			if(isset($value['url'.$name]))
+			{
+				$links[] = [
+					'url'  => $value['url'.$name],
+					'text' => $value['url'.$name.'text']
+				];
+			}
+		}
+
+		return new KObjectConfigJson($links);
+	}
+
+	public function setPropertyParameters($value)
+	{
+		if(is_string($value)) {
+			$value = json_decode($value, true);
+		}
+
+		//$params = JComponentHelper::getParams('com_content')->toArray();
+
+		$config  = new KObjectConfigJson(/*$params*/);
+		$config->merge($value); // Override global params with specific params
+
+		return $config;
+	}
+
+	public function getEditor()
+	{
+		$user = $this->getObject('user.provider')->load($this->editor);
+		return $user;
+	}
+}

--- a/code/site/components/com_pages/resources/extensions/joomla/model/entity/category.php
+++ b/code/site/components/com_pages/resources/extensions/joomla/model/entity/category.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Joomlatools Pages
+ *
+ * @copyright   Copyright (C) 2018 Johan Janssens and Timble CVBA. (http://www.timble.net)
+ * @license     GNU GPLv3 <http://www.gnu.org/licenses/gpl.html>
+ * @link        https://github.com/joomlatools/joomlatools-pages for the canonical source repository
+ */
+
+class ExtJoomlaModelEntityCategory extends ExtJoomlaModelEntityAbstract
+{
+	protected function _initialize(KObjectConfig $config)
+	{
+		$config->append([
+			'data' => [
+				'id'		  => '',
+				'slug'        => '',
+				'name'        => '',
+				'title'       => '',
+				'summary'     => '',
+				'text'        => '',
+ 				'date'        => 'now',
+				'edited_date' => '',
+				'author'      => '',
+				'editor'      => '',
+				'image'       => [
+					'url' 	   => '',
+					'alt'	   => '',
+					'caption'  => '',
+				],
+				'metadata'    => [
+					'og:type'        => 'website',
+					'og:title'       => null,
+					'og:url'         => null,
+					'og:image'       => null,
+					'og:description' => null,
+				],
+				'parameters'  => [],
+				'impressions' => 0,
+				'direction'   => 'auto',
+				'language'    => 'en-GB',
+			],
+		]);
+
+		parent::_initialize($config);
+	}
+
+	public function getPropertyImage()
+	{
+		$image = array();
+
+		if($this->parameters->image)
+		{
+			$url = $this->parameters->image;
+
+			if(is_string($url) && strpos($url, '://') === false) {
+				$url =  $this->getBasePath().'/'.ltrim($url, '/');
+			}
+
+			$url = $this->getObject('lib:http.url')->setUrl($url);
+
+			$image = [
+				'url'      => $url,
+				'alt'      => $this->parameters->image_alt ?? '',
+				'caption'  => '',
+			];
+		}
+
+		return new KObjectConfigJson($image);
+	}
+
+	public function setPropertyEditedDate($value)
+	{
+		$date = null;
+
+		if($value && $value != '0000-00-00 00:00:00')
+		{
+			if(is_integer($value)) {
+				$date = $this->getObject('date')->setTimestamp($value);
+			} else {
+				$date = $this->getObject('date', array('date' => trim($value)));
+			}
+		}
+
+		return $date;
+	}
+
+	public function setPropertyParameters($value)
+	{
+		if(is_string($value)) {
+			$value = json_decode($value, true);
+		}
+
+		//$params = JComponentHelper::getParams('com_content')->toArray();
+
+		$config  = new KObjectConfigJson(/*$params*/);
+		$config->merge($value); // Override global params with article specific params
+
+		return $config;
+	}
+
+	public function getEditor()
+	{
+		$user = $this->getObject('user.provider')->load($this->editor);
+		return $user;
+	}
+}

--- a/code/site/components/com_pages/resources/extensions/joomla/model/fields.php
+++ b/code/site/components/com_pages/resources/extensions/joomla/model/fields.php
@@ -1,0 +1,94 @@
+<?php
+class ExtJoomlaModelFields extends ComPagesModelDatabase
+{
+	public function __construct(KObjectConfig $config)
+	{
+		parent::__construct($config);
+
+		$this->getState()
+			->insert('id', 'cmd', null, true)
+			->insert('group'     , 'int')
+			->insert('article'   , 'int')
+			->insert('published' , 'bool');
+	}
+
+	protected function _initialize(KObjectConfig $config)
+	{
+		$config->append(array(
+			'persistable' => false,
+			'type'   => 'article_fields',
+			'entity' => 'field',
+			'table'  => 'fields',
+		));
+		parent::_initialize($config);
+	}
+
+	public function fetchData($count = false)
+	{
+		$state = $this->getState();
+
+		$query = $this->getObject('database.query.select')
+			->table(array('tbl' => $this->getTable()->getName()));
+
+		if(!$count)
+		{
+			$query->columns([
+				'id'        => 'tbl.id',
+				'name'      => 'tbl.name',
+				'title'     => 'tbl.title',
+				'type'      => 'tbl.type',
+				'value'     => 'v.value',
+				'published' => 'IF(tbl.state = 1, 1, 0)',
+			]);
+		}
+		else $query->columns('COUNT(*)');
+
+		//Joins
+		$query
+			->join(['v' => 'fields_values'], 'tbl.id = v.field_id');
+
+		if(!is_null($state->id))
+		{
+			if(is_string($state->id)) {
+				$fields = array_unique(explode(',',  $state->id));
+			} else {
+				$fields = (array) $state->id;
+			}
+
+			$query->where('(tbl.id IN :fields)')->bind(['fields' => $fields]);
+		}
+
+		if(!is_null($state->article))
+		{
+			if(is_string($state->article)) {
+				$articles = array_unique(explode(',',  $state->article));
+			} else {
+				$articles = (array) $state->article;
+			}
+
+			$query->where('(v.item_id IN :articles)')->bind(['articles' => $articles]);
+		}
+
+		if(!is_null($state->group))
+		{
+			if(is_string($state->group)) {
+				$groups = array_unique(explode(',',  $state->group));
+			} else {
+				$groups = (array) $state->group;
+			}
+
+			$query->where('(tbl.group_id IN :groups)')->bind(['groups' => $groups]);
+		}
+
+		if (!is_null($state->published))
+		{
+			if($state->published) {
+				$query->where('(tbl.state = 1)');
+			} else {
+				$query->where('(tbl.state = 0');
+			}
+		}
+
+		return $query;
+	}
+}


### PR DESCRIPTION
This PR implements support for Joomla content: `articles`, `categories` and `fields` through the 'ext:joomla`extension namespace. Following collection models are available:

- `ext:joomla.model.articles`
- `ext:joomla.model.categories`
- `ext:joomla.model.fields`

