### PR TITLE
Error handling not working

### DIFF
--- a/code/site/components/com_pages/controller/abstract.php
+++ b/code/site/components/com_pages/controller/abstract.php
@@ -84,18 +84,21 @@ class ComPagesControllerAbstract extends KControllerModel
 
     protected function _actionRender(KControllerContextInterface $context)
     {
-        $route    = $context->router->generate($context->route);
-        $location = $context->router->qualify($route);
+        if(!$context->response->isError())
+        {
+            $route    = $context->router->generate($context->route);
+            $location = $context->router->qualify($route);
 
-        /**
-         * If Content-Location is included in a 2xx (Successful) response message and its value refers (after
-         * conversion to absolute form) to a URI that is the same as the effective request URI, then the recipient
-         * MAY consider the payload to be a current representation of that resource at the time indicated by the
-         * message origination date
-         *
-         * See: https://tools.ietf.org/html/rfc7231#section-3.1.4.2
-         */
-        $context->response->headers->set('Content-Location', $location);
+            /**
+             * If Content-Location is included in a 2xx (Successful) response message and its value refers (after
+             * conversion to absolute form) to a URI that is the same as the effective request URI, then the recipient
+             * MAY consider the payload to be a current representation of that resource at the time indicated by the
+             * message origination date
+             *
+             * See: https://tools.ietf.org/html/rfc7231#section-3.1.4.2
+             */
+            $context->response->headers->set('Content-Location', $location);
+        }
 
         return parent::_actionRender($context);
     }

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -287,6 +287,9 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
             {
                 if($page = $this->getObject('page.registry')->getPageEntity($code))
                 {
+                    //Set status code (before rendering the error)
+                    $context->response->setStatus($code);
+
                     //Set the controller
                     $this->setController($page->getType(), ['page' => $page]);
 
@@ -295,9 +298,6 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
 
                     //Set error in the response
                     $context->response->setContent($content);
-
-                    //Set status code
-                    $context->response->setStatus($code);
 
                     return true;
                 }

--- a/code/site/components/com_pages/event/subscriber/errorhandler.php
+++ b/code/site/components/com_pages/event/subscriber/errorhandler.php
@@ -9,6 +9,12 @@
 
 class ComPagesEventSubscriberErrorhandler extends ComPagesEventSubscriberAbstract
 {
+    public function onAfterKoowaBootstrap(KEventInterface $event)
+    {
+        //Catch all Joomla exceptions
+        JError::setErrorHandling(E_ERROR, 'callback', array($this, 'handleException'));
+    }
+
     public function onException(KEventException $event)
     {
         if($this->getObject('request')->getFormat() == 'html')
@@ -21,5 +27,10 @@ class ComPagesEventSubscriberErrorhandler extends ComPagesEventSubscriberAbstrac
         }
 
         return false;
+    }
+
+    public function handleException(\Exception $exception)
+    {
+        $this->getObject('exception.handler')->handleException($exception);
     }
 }

--- a/code/site/components/com_pages/template/helper/behavior.php
+++ b/code/site/components/com_pages/template/helper/behavior.php
@@ -51,7 +51,7 @@ ANCHOR;
         $config = new KObjectConfigJson($config);
         $config->append(array(
             'debug'    =>  JFactory::getApplication()->getCfg('debug'),
-            'selector' => '',
+            'selector' => 'header',
             'onload'   => $this->getObject('dispatcher')->isCacheable(),
             'onhover'  => $this->getObject('dispatcher')->isCacheable(),
         ));


### PR DESCRIPTION
This PR fixes #453 and also adds a catch all for all Joomla exceptions and routes them through the pages error handling.