### PR TITLE
Handle multiple nested constraints correctly

### DIFF
--- a/code/site/components/com_pages/model/behavior/filterable.php
+++ b/code/site/components/com_pages/model/behavior/filterable.php
@@ -55,29 +55,33 @@ class ComPagesModelBehaviorFilterable extends ComPagesModelBehaviorQueryable
             {
                 foreach ($filters as $attribute => $values)
                 {
-                    //Support multiple constraints on the same attribute
-                    foreach((array) $values as $key => $value)
+                    //Multiple constraints on the same attribute
+                    foreach((array) $values as $key => $v)
                     {
-                        // Parse filter value for possible operator
-                        if (preg_match('#^([eq|neq|gt|gte|lt|lte|in|nin]+):(.+)\s*$#i', $value, $matches))
+                        //With one level nesting
+                        foreach((array) $v as $value)
                         {
-                            $this->_filters[] = [
-                                'attribute' => $attribute,
-                                'key'       => !is_numeric($key) ? $key : null,
-                                'operation' => $matches[1],
-                                'values' => array_unique(explode(',', $matches[2])),
-                                'combination' => 'AND'
-                            ];
-                        }
-                        else
-                        {
-                            $this->_filters[] = [
-                                'attribute' => $attribute,
-                                'key'       => !is_numeric($key) ? $key : null,
-                                'operation' => 'eq',
-                                'values' => array_unique(explode(',', $value)),
-                                'combination' => 'AND'
-                            ];
+                            // Parse filter value for possible operator
+                            if (preg_match('#^([eq|neq|gt|gte|lt|lte|in|nin]+):(.+)\s*$#i', $value, $matches))
+                            {
+                                $this->_filters[] = [
+                                    'attribute' => $attribute,
+                                    'key'       => !is_numeric($key) ? $key : null,
+                                    'operation' => $matches[1],
+                                    'values' => array_unique(explode(',', $matches[2])),
+                                    'combination' => 'AND'
+                                ];
+                            }
+                            else
+                            {
+                                $this->_filters[] = [
+                                    'attribute' => $attribute,
+                                    'key'       => !is_numeric($key) ? $key : null,
+                                    'operation' => 'eq',
+                                    'values' => array_unique(explode(',', $value)),
+                                    'combination' => 'AND'
+                                ];
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR #closed #476 and fixes and issue with multiple nested filter constraints not working. See also: https://github.com/joomlatools/joomlatools-pages/pull/413

For example, get a list of all the pages that are indexable:

### Through frontmatter

````yaml
---
collection:
    model: pages
    state:
         filter:
            metadata:
                robots:  ['nin:noindex', 'nin:none'],
---
````

### Through url

`http://example.com/bar?filter[metadata][robots][]=nin:noindex&filter[metadata][robots][]=nin:none`

### Through code

````php
<? $pages = collection('pages', [
    'filter' => [
        'metadata' => [
            'robots' => ['nin:noindex', 'nin:none'],
        ],
    ]
]); ?>