### PR TITLE
Improve webservice collection

### DIFF
--- a/code/administrator/components/com_pages/pages.xml
+++ b/code/administrator/components/com_pages/pages.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="component" version="0.19.0" method="upgrade">
+<extension type="component" version="0.19.1" method="upgrade">
     <identifier>com:pages</identifier>
     <name>com_pages</name>
     <author>Joomlatools</author>
@@ -8,7 +8,7 @@
     <license>GNU GPLv3 - http://www.gnu.org/licenses/gpl.html</license>
     <authorEmail>support@joomlatools.com</authorEmail>
     <authorUrl>www.joomlatools.com</authorUrl>
-    <version>0.19.0</version>
+    <version>0.19.1</version>
     <description>COM_PAGES_XML_DESCRIPTION</description>
 
     <files folder="site/components/com_pages">

--- a/code/administrator/components/com_pages/version.php
+++ b/code/administrator/components/com_pages/version.php
@@ -8,7 +8,7 @@
  */
 class ComPagesVersion extends KObject
 {
-    const VERSION = '0.19.0';
+    const VERSION = '0.19.1';
 
     public function getVersion()
     {

--- a/code/site/components/com_pages/model/webservice.php
+++ b/code/site/components/com_pages/model/webservice.php
@@ -32,6 +32,7 @@ class ComPagesModelWebservice extends ComPagesModelCollection
             'url'          => '',
             'data'         => '',
             'cache'        => null,
+            'headers'      => array()
         ]);
 
         parent::_initialize($config);
@@ -40,6 +41,11 @@ class ComPagesModelWebservice extends ComPagesModelCollection
     public function getUrl(array $variables = array())
     {
         return KHttpUrl::fromTemplate($this->_url, $variables);
+    }
+
+    public function getHeaders()
+    {
+        return KObjectConfig::unbox($this->getConfig()->headers);
     }
 
     public function getHash($refresh = false)
@@ -51,7 +57,8 @@ class ComPagesModelWebservice extends ComPagesModelCollection
             $http    = $this->_getHttpClient();
 
             $max_age = $refresh ? 0 : $this->getConfig()->cache;
-            $headers = ['Cache-Control' => $this->_getCacheControl($max_age)];
+            $headers = $this->getHeaders();
+            $headers['Cache-Control'] = $this->_getCacheControl($max_age);
 
             try
             {
@@ -83,7 +90,9 @@ class ComPagesModelWebservice extends ComPagesModelCollection
                 $http    = $this->_getHttpClient();
 
                 $max_age = $this->getConfig()->cache;
-                $headers = ['Cache-Control' => $this->_getCacheControl($max_age)];
+
+                $headers = $this->getHeaders();
+                $headers['Cache-Control'] = $this->_getCacheControl($max_age);
 
                 try {
                     $this->__data = $http->get($url, $headers);
@@ -136,8 +145,9 @@ class ComPagesModelWebservice extends ComPagesModelCollection
 
         $http    = $this->_getHttpClient();
         $url     = $this->getUrl($this->getState()->getValues());
-        $headers = ['Origin' => $url->toString(KHttpUrl::AUTHORITY)];
 
+        $headers = $this->getHeaders();
+        $headers['Origin'] = $url->toString(KHttpUrl::AUTHORITY);
 
         $data   = array();
         if(!$context->state->isUnique())


### PR DESCRIPTION
This PR closes #478 and adds a new `headers` config option to easily define custom headers. For example:

```yaml
---
collection:
    model: webservice
    config:
        url: http://www.example.com/api/records.json
        headers: 
            Authorization: Bearer [key]
---
```