### PR TITLE
Do not cache statically if must-revalidate

### DIFF
--- a/code/site/components/com_pages/event/subscriber/staticcache.php
+++ b/code/site/components/com_pages/event/subscriber/staticcache.php
@@ -23,8 +23,8 @@ class ComPagesEventSubscriberStaticcache extends ComPagesEventSubscriberAbstract
             $file = $this->getFilePath($dispatcher);
             $dir  = dirname($file);
 
-            //Only cache statically if no max-age is defined
-            if($file && $response->getMaxAge() === NULL)
+            //Only cache statically if must not revalidate
+            if($file && !in_array('must-revalidate', $response->getCacheControl()))
             {
                 // Cache needs to be regenerated OR cache doesn't exist yet
                 $regenerate = !$dispatcher->isIdentical() || !file_exists($file);


### PR DESCRIPTION
This PR closes #490 and improve the static caching logic. A page will not be cached statically if it must be revalidated. This allows to set a global cache time for the static cache and still define a different cache time per page. 