### PR TITLE
Do not intercept none-sef request

### DIFF
--- a/code/site/components/com_pages/event/subscriber/dispatcher.php
+++ b/code/site/components/com_pages/event/subscriber/dispatcher.php
@@ -18,6 +18,18 @@ class ComPagesEventSubscriberDispatcher extends ComPagesEventSubscriberAbstract
         parent::_initialize($config);
     }
 
+    public function isEnabled()
+    {
+        $result = parent::isEnabled();
+
+        //Disable dispatcher if directly routing to a component
+        if(isset($_REQUEST['option']) && substr($_REQUEST['option'], 0, 4) == 'com_') {
+            $result = false;
+        }
+
+        return $result;
+    }
+
     public function onAfterApplicationInitialise(KEventInterface $event)
     {
         $dispatcher = $this->getObject('com://site/pages.dispatcher.http');

--- a/code/site/components/com_pages/event/subscriber/errorhandler.php
+++ b/code/site/components/com_pages/event/subscriber/errorhandler.php
@@ -9,6 +9,18 @@
 
 class ComPagesEventSubscriberErrorhandler extends ComPagesEventSubscriberAbstract
 {
+    public function isEnabled()
+    {
+        $result = parent::isEnabled();
+
+        //Disable error handler if directly routing to a component
+        if(isset($_REQUEST['option']) && substr($_REQUEST['option'], 0, 4) == 'com_') {
+            $result = false;
+        }
+
+        return $result;
+    }
+
     public function onAfterKoowaBootstrap(KEventInterface $event)
     {
         //Catch all Joomla exceptions

--- a/code/site/components/com_pages/event/subscriber/pagedecorator.php
+++ b/code/site/components/com_pages/event/subscriber/pagedecorator.php
@@ -20,6 +20,18 @@ class ComPagesEventSubscriberPagedecorator extends ComPagesEventSubscriberAbstra
         parent::_initialize($config);
     }
 
+    public function isEnabled()
+    {
+        $result = parent::isEnabled();
+
+        //Disable page decorator if directly routing to a component
+        if(isset($_REQUEST['option']) && substr($_REQUEST['option'], 0, 4) == 'com_') {
+            $result = false;
+        }
+
+        return $result;
+    }
+
     public function onAfterApplicationRoute(KEventInterface $event)
     {
         //Try to validate the cache


### PR DESCRIPTION
This PR closes #498 and solves an issue with Pages trying to dispatch none-sef request. This fix checks of the request contains `option=com_[foo]` and if this is the case disabled the pages dispatcher, error handler and page decorator.