### PR TITLE
Do not cache redirects

### DIFF
--- a/code/site/components/com_pages/dispatcher/behavior/cacheable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/cacheable.php
@@ -178,7 +178,7 @@ class ComPagesDispatcherBehaviorCacheable extends KDispatcherBehaviorCacheable
         $result   = false;
         $response = $context->getResponse();
 
-        if($response->isCacheable() && !$response->isError())
+        if($response->isCacheable() && $response->isSuccess())
         {
             //Reset the date and last-modified
             $response->setDate(new DateTime('now'));

--- a/code/site/components/com_pages/event/subscriber/staticcache.php
+++ b/code/site/components/com_pages/event/subscriber/staticcache.php
@@ -18,7 +18,7 @@ class ComPagesEventSubscriberStaticcache extends ComPagesEventSubscriberAbstract
         $response   = $dispatcher->getResponse();
 
         //Only cache static pages without a query string
-        if(!$dispatcher->getContentLocation()->getQuery() && $this->getConfig()->cache_path)
+        if($event->result && !$dispatcher->getContentLocation()->getQuery() && $this->getConfig()->cache_path)
         {
             $file = $this->getFilePath($dispatcher);
             $dir  = dirname($file);
@@ -51,8 +51,15 @@ class ComPagesEventSubscriberStaticcache extends ComPagesEventSubscriberAbstract
             else
             {
                 //Purge the static cache
-                if(file_exists($file)) {
+                if(file_exists($file))
+                {
                     unlink($file);
+
+                    //Delete the folder if its empty
+                    $dir = dirname($file);
+                    if(!(new \FilesystemIterator($dir))->valid()) {
+                        rmdir($dir);
+                    }
                 }
             }
         }
@@ -63,8 +70,15 @@ class ComPagesEventSubscriberStaticcache extends ComPagesEventSubscriberAbstract
         $file = $this->getFilePath($event->getTarget());
 
         //Purge the static cache
-        if(file_exists($file)) {
+        if(file_exists($file))
+        {
             unlink($file);
+
+            //Delete the folder if its empty
+            $dir = dirname($file);
+            if(!(new \FilesystemIterator($dir))->valid()) {
+                rmdir($dir);
+            }
         }
     }
 

--- a/code/site/components/com_pages/resources/server/apache.txt
+++ b/code/site/components/com_pages/resources/server/apache.txt
@@ -15,10 +15,7 @@
     RewriteRule ^joomlatools-pages/cache/static - [END,R=404]
 
     # Condition - Do not serve from cache on browser refresh or when caching is not allowed
-    RewriteCond %{HTTP:Cache-Control} ^(must-revalidate)$ [OR]
-    RewriteCond %{HTTP:Cache-Control} ^(no-store)$ [OR]
-    RewriteCond %{HTTP:Cache-Control} ^(no-cache)$ [OR]
-    RewriteCond %{HTTP:Cache-Control} ^(max-age=0)$
+    RewriteCond %{HTTP:Cache-Control} (must-revalidate|max-age|no-cache|no-store)
     RewriteRule .* - [S=4]
 
     # Condition - Only return cache for none logged in GET request


### PR DESCRIPTION
This PR closes #500 and prevents redirects from getting cached. It also improves the staticcache handler and only caches statically if the cache returned true. 