### PR TITLE
Improve redirect routing

### DIFF
--- a/code/site/components/com_pages/config.php
+++ b/code/site/components/com_pages/config.php
@@ -47,8 +47,8 @@ class ComPagesConfig extends KObject implements KObjectSingleton
             'http_cache_control'         => array(),
             'http_cache_control_private' => array('private', 'no-cache'),
 
-            'http_static_cache'         => getenv('PAGES_STATIC_PATH') ? true : false,
-            'http_static_cache_path'    => getenv('PAGES_STATIC_PATH') ? $_SERVER['DOCUMENT_ROOT'].getenv('PAGES_STATIC_PATH') : false,
+            'http_static_cache'         => getenv('PAGES_STATIC_ROOT') ? true : false,
+            'http_static_cache_path'    => getenv('PAGES_STATIC_ROOT') ? getenv('PAGES_STATIC_ROOT') : false,
 
             'http_resource_cache'       => JFactory::getConfig()->get('caching'),
             'http_resource_cache_time'  => '1day',

--- a/code/site/components/com_pages/dispatcher/behavior/redirectable.php
+++ b/code/site/components/com_pages/dispatcher/behavior/redirectable.php
@@ -42,6 +42,12 @@ class ComPagesDispatcherBehaviorRedirectable extends KControllerBehaviorAbstract
             $context->getResponse()->getHeaders()->set('Location',  $url);
             $context->getResponse()->setStatus($status);
 
+            //Purge the cache
+            $dispatcher = $this->getObject('com://site/pages.dispatcher.http');
+            if($dispatcher->isCacheable()) {
+                $dispatcher->purge();
+            }
+
             $context->getSubject()->send();
         }
     }

--- a/code/site/components/com_pages/dispatcher/http.php
+++ b/code/site/components/com_pages/dispatcher/http.php
@@ -88,7 +88,15 @@ class ComPagesDispatcherHttp extends ComKoowaDispatcherHttp
         {
             $base  = $this->getRequest()->getBasePath();
             $url   = urldecode($this->getRequest()->getUrl()->getPath());
-            $path  = trim(str_replace(array($base, '/index.php'), '', $url), '/');
+
+            //Strip script name if request is rewritten
+            if(isset($_SERVER['PAGES_PATH'])) {
+                $path = str_replace(array($base, $_SERVER['SCRIPT_NAME']), '', $url);
+            } else {
+                $path = str_replace($base, '', $url);
+            }
+
+            $path  = trim($path, '/');
             $query = $this->getRequest()->getUrl()->getQuery(true);
 
             $this->__route = $this->getRouter()->resolve('pages:'.$path,  $query);

--- a/code/site/components/com_pages/dispatcher/router/abstract.php
+++ b/code/site/components/com_pages/dispatcher/router/abstract.php
@@ -143,12 +143,12 @@ abstract class ComPagesDispatcherRouterAbstract extends KObject implements ComPa
             //Qualify the url
             $url->setUrl($request->getUrl()->toString(KHttpUrl::AUTHORITY));
 
-            //Add index.php
             $base = $request->getBasePath();
             $path = trim($url->getPath(), '/');
 
-            if(strpos($request->getUrl()->getPath(), 'index.php') !== false) {
-                $url->setPath($base . '/index.php/' . $path);
+            //Add script name (index.php) if request is not rewritten
+            if(!isset($_SERVER['PAGES_PATH'])) {
+                $url->setPath($base . $_SERVER['SCRIPT_NAME'].'/' . $path);
             } else {
                 $url->setPath($base.'/'.$path);
             }

--- a/code/site/components/com_pages/dispatcher/router/redirect.php
+++ b/code/site/components/com_pages/dispatcher/router/redirect.php
@@ -26,33 +26,19 @@ class ComPagesDispatcherRouterRedirect extends ComPagesDispatcherRouterAbstract
     {
         if(!$route)
         {
-            $base   = $this->getRequest()->getBasePath();
-            $url    = urldecode( $this->getRequest()->getUrl()->getPath());
+            $base = $this->getRequest()->getBasePath();
+            $url  = urldecode( $this->getRequest()->getUrl()->getPath());
 
-            $route  = trim($url, '/');
+            //Strip script name if request is not rewritten (allow to redirect /index.php/)
+            if(!isset($_SERVER['PAGES_PATH'])) {
+                $route = str_replace(array($base, $_SERVER['SCRIPT_NAME']), '', $url);
+            } else {
+                $route = str_replace($base, '', $url);
+            }
+
+            $route = trim($route, '/');
         }
 
         return parent::resolve($route, $parameters);
-    }
-
-    public function qualify(ComPagesDispatcherRouterRouteInterface $route,  $replace = false)
-    {
-        $url = clone $route;
-
-        if($replace || !$route->isAbsolute())
-        {
-            $request = $this->getRequest();
-
-            //Qualify the url
-            $url->setUrl($request->getUrl()->toString(KHttpUrl::AUTHORITY));
-
-            //Add index.php
-            $base = $request->getBasePath();
-            $path = trim($url->getPath(), '/');
-
-            $url->setPath($base.'/'.$path);
-        }
-
-        return $url;
     }
 }

--- a/code/site/components/com_pages/dispatcher/router/redirect.php
+++ b/code/site/components/com_pages/dispatcher/router/redirect.php
@@ -29,9 +29,30 @@ class ComPagesDispatcherRouterRedirect extends ComPagesDispatcherRouterAbstract
             $base   = $this->getRequest()->getBasePath();
             $url    = urldecode( $this->getRequest()->getUrl()->getPath());
 
-            $route  = trim(str_replace(array($base, '/index.php'), '', $url), '/');
+            $route  = trim($url, '/');
         }
 
         return parent::resolve($route, $parameters);
+    }
+
+    public function qualify(ComPagesDispatcherRouterRouteInterface $route,  $replace = false)
+    {
+        $url = clone $route;
+
+        if($replace || !$route->isAbsolute())
+        {
+            $request = $this->getRequest();
+
+            //Qualify the url
+            $url->setUrl($request->getUrl()->toString(KHttpUrl::AUTHORITY));
+
+            //Add index.php
+            $base = $request->getBasePath();
+            $path = trim($url->getPath(), '/');
+
+            $url->setPath($base.'/'.$path);
+        }
+
+        return $url;
     }
 }

--- a/code/site/components/com_pages/dispatcher/router/resolver/regex.php
+++ b/code/site/components/com_pages/dispatcher/router/resolver/regex.php
@@ -353,11 +353,12 @@ class ComPagesDispatcherRouterResolverRegex  extends ComPagesDispatcherRouterRes
                 unset($route->query[$param]);
             }
 
-            if(strpos($regex, '://') === false) {
-                $route->setPath('/'.ltrim($regex, '/'));
-            } else {
+            if(strpos($regex, '://') !== false)
+            {
+                $route-> path = ''; //Reset the path
                 $route->setUrl($regex);
             }
+            else $route->setPath('/'.ltrim($regex, '/'));
         }
 
         return $result;


### PR DESCRIPTION
This PR closes #502 and allows the redirect router to handle /index.php in routes if the request is rewritten if not /index.php/ will not be considered as part of the path. 

The PR also adds support for redirect cache purging. This is useful when you are changing a page to a redirect, or when you move from /index.php to / rewrites and you need the cache to be cleaned. 