### PR TITLE
Set PAGES_PATH based on Joomla configuration

### DIFF
--- a/code/site/components/com_pages/event/subscriber/bootstrapper.php
+++ b/code/site/components/com_pages/event/subscriber/bootstrapper.php
@@ -66,6 +66,11 @@ class ComPagesEventSubscriberBootstrapper extends ComPagesEventSubscriberAbstrac
 
             JFactory::getApplication()->setTemplate($template, $params);
         }
+
+        //Set PAGES_PATH based on Joomla configuration
+        if(JFactory::getApplication()->getCfg('sef_rewrite')) {
+            $_SERVER['PAGES_PATH'] = JFactory::getApplication()->getCfg('live_site') ?? '/';
+        }
     }
 
     protected function _bootstrapSite($path, $config = array())


### PR DESCRIPTION
This PR closes #507 and sets the PAGES_PATH env variable based on the Joomla configuration. This prevents the need to set it manually.