### PR TITLE
Improve remote data caching

### DIFF
--- a/code/site/components/com_pages/config.php
+++ b/code/site/components/com_pages/config.php
@@ -51,9 +51,7 @@ class ComPagesConfig extends KObject implements KObjectSingleton
             'http_static_cache_path'    => getenv('PAGES_STATIC_ROOT') ? getenv('PAGES_STATIC_ROOT') : false,
 
             'http_resource_cache'       => JFactory::getConfig()->get('caching'),
-            'http_resource_cache_time'  => '1day',
             'http_resource_cache_path'  => $config->site_path ? $config->site_path.'/cache/resources' : false,
-            'http_resource_cache_force' => false,
             'http_resource_cache_debug' => (JDEBUG ? true : false),
 
             'collections' => array(),

--- a/code/site/components/com_pages/http/cache.php
+++ b/code/site/components/com_pages/http/cache.php
@@ -21,7 +21,6 @@ class ComPagesHttpCache extends KHttpClient
         $config->append([
             'cache'      => false,
             'cache_path' => $this->getObject('com://site/pages.config')->getSitePath('cache'),
-            'cache_time' => '1day',
             'debug'      => JDEBUG ? true : false,
 
         ]);
@@ -199,21 +198,11 @@ class ComPagesHttpCache extends KHttpClient
         $stale = false;
         $cache_control = $request->getCacheControl();
 
-        if(!isset($cache_control['max-age']))
+        if(isset($cache_control['max-age']))
         {
-            $max_age = $this->getConfig()->cache_time;
-
-            //Convert max_age to seconds
-            if(!is_numeric($max_age))
-            {
-                if($max_age = strtotime($max_age)) {
-                    $max_age = $max_age - strtotime('now');
-                }
-            }
+            $max_age = (int) $cache_control['max-age'];
+            $stale = ($max_age - $response->getAge()) <= 0;
         }
-        else $max_age = $cache_control['max-age'];
-
-        $stale = ($max_age - $response->getAge()) <= 0;
 
         return $stale;
     }

--- a/code/site/components/com_pages/model/webservice.php
+++ b/code/site/components/com_pages/model/webservice.php
@@ -31,7 +31,7 @@ class ComPagesModelWebservice extends ComPagesModelCollection
             'entity'       => 'resource',
             'url'          => '',
             'data'         => '',
-            'cache'        => null,
+            'cache'        => true,
             'headers'      => array()
         ]);
 
@@ -54,11 +54,11 @@ class ComPagesModelWebservice extends ComPagesModelCollection
 
         if($url = $this->getUrl($this->getState()->getValues()))
         {
-            $http    = $this->_getHttpClient();
+            $http = $this->_getHttpClient();
 
-            $max_age = $refresh ? 0 : $this->getConfig()->cache;
+            $cache   = $refresh ? 0 : $this->getConfig()->cache;
             $headers = $this->getHeaders();
-            $headers['Cache-Control'] = $this->_getCacheControl($max_age);
+            $headers['Cache-Control'] = $this->_getCacheControl($cache);
 
             try
             {
@@ -227,21 +227,22 @@ class ComPagesModelWebservice extends ComPagesModelCollection
         return $this->__http;
     }
 
-    protected function _getCacheControl($max_age = null)
+    protected function _getCacheControl($cache)
     {
         $cache_control = array();
 
-        if($max_age !== null)
+        if($cache !== true)
         {
-            if($max_age !== false)
+            if($cache !== false)
             {
                 //Convert max_age to seconds
-                if(!is_numeric($max_age))
+                if(!is_numeric($cache))
                 {
-                    if($max_age = strtotime($max_age)) {
+                    if($max_age = strtotime($cache)) {
                         $max_age = $max_age - strtotime('now');
                     }
                 }
+                else $max_age = $cache;
 
                 $cache_control = ['max-age' => (int) $max_age];
             }

--- a/code/site/components/com_pages/template/default.php
+++ b/code/site/components/com_pages/template/default.php
@@ -268,7 +268,7 @@ class ComPagesTemplateDefault extends KTemplate
         return $result;
     }
 
-    protected function _fetchData($path)
+    protected function _fetchData($path, $cache = true)
     {
         $result = false;
         if(is_array($path))
@@ -298,7 +298,7 @@ class ComPagesTemplateDefault extends KTemplate
             if(!in_array($namespace, ['http', 'https'])) {
                 $result = $this->getObject('data.registry')->fromPath($path);
             } else {
-                $result = $this->getObject('data.registry')->fromUrl($path);
+                $result = $this->getObject('data.registry')->fromUrl($path, $cache);
             }
         }
 


### PR DESCRIPTION
This PR closes #511 and adds support for configuring the data remote data cache through the template `data()`function.

### Configure remote data cache

The `data([url], [cache])`template function now accepts a second `cache` parameter that allows to define the caching behavior for remote data fetched by url. By default caching is enabled and the data will not be revalidated.

The `cache` parameter accepts following options:

- `true`: enabled the cache (default)
- `false`: disabled the cache
- '3600`: time in seconds the cache is valid
- `1day`: an English textual relative datetime format the cache is valid

Example: `<? $data = data([url], '1day'); ?>`

#### Configuration changes

This PR also removed the following configuration options

- `http_resource_cache_time` 
- `http_resource_cache_force`

Both options are no longer used http caching needs to be defined per webservice collection, or through the data template function for remote data. There is no longer a global setting. 