### PR TITLE
Allow to define searchable collection properties

### DIFF
--- a/code/site/components/com_pages/model/collection.php
+++ b/code/site/components/com_pages/model/collection.php
@@ -41,18 +41,20 @@ abstract class ComPagesModelCollection extends KModelAbstract implements ComPage
     protected function _initialize(KObjectConfig $config)
     {
         $config->append([
-            'entity' => $this->getIdentifier()->getName(),
-            'type'             => '', //the collection type used when generating JSDNAPI
-            'name'             => '', //the collection name used to generate this model
-            'identity_key'     => null,
+            'entity'        => $this->getIdentifier()->getName(),
+            'type'          => '', //the collection type used when generating JSDNAPI
+            'name'          => '', //the collection name used to generate this model
+            'search'        => [], //properties to allow searching on
+            'identity_key'  => null,
+            'persistable'   => false,
+        ])->append([
             'behaviors'   => [
                 'com://site/pages.model.behavior.paginatable',
                 'com://site/pages.model.behavior.sortable',
-                'com://site/pages.model.behavior.searchable',
                 'com://site/pages.model.behavior.sparsable',
                 'com://site/pages.model.behavior.filterable',
+                'com://site/pages.model.behavior.searchable' => ['columns' => $config->search],
             ],
-            'persistable' => false,
         ]);
 
         parent::_initialize($config);


### PR DESCRIPTION
This PR closes #513 and allows to define the searchable collection properties through the collection frontmatter definition.

The data properties that can be searched on need to be defined, if no properties are defined search will not work. You can define one or multiple properties to search on. 

_Note:_ searching is done on the raw data, not on the processed entities, converting the data to entities happens after the data has been retrieved from the datastore.

### Example:

To allow search on the name and email of a user define the `name` and `email` property as searcheable create a file `/joomlatools-pages/pages/users.html.php` with the following definition:

```yaml
---
collection:
    model: database?table=users
    config:
        search: [name, email]
---
```
```php
<ul>
<? foreach(collection() as $user): ?>
<li><?= $user->name ?> (<?= $user->email ?>)</li>
<? endforeach ?>
</ul>
````

### Searching through PHP

Anywhere in your code you can now re-use the `users` collection and search on it to retrieve a subset of the data.  

#### Searching on all defined properties

`<? $users =  collection('users', ['search' => 'jack') ?>`

#### Searching on a specific property

It's also possible to search on a specific property only by prepending the search word with the property name separated by a semi-colon

`<? $users =  collection('users', ['search' => 'name:jack') ?>` (search for all users that have jack in their name)

or 

`<? $users =  collection('users', ['search' => 'email:foo.com') ?>` (search for all users that have jack in their name)


### Searching through the URL

You can also use the URL to list a subset of the users by searching it.

#### Searching on all defined properties

`http://example.com/users?search=jack`

#### Searching on a specific property

It's also possible to search on a specific property only by prepending the search word with the property name seperated by a semi-colon

`http://example.com/users?search=name:jack` (search for all users that have jack in their name)

or

`http://example.com/users?search=email:foo.com` (search for all users that are part of the foo.com domain)
