### PR TITLE
Filesystem collection identity issue

### DIFF
--- a/code/site/components/com_pages/model/collection.php
+++ b/code/site/components/com_pages/model/collection.php
@@ -245,7 +245,7 @@ abstract class ComPagesModelCollection extends KModelAbstract implements ComPage
         }
 
         foreach($data as $properties) {
-            $entity->create($properties);
+            $entity->create($properties, ComPagesModelEntityItem::STATUS_CREATED);
         }
 
         return $entity;

--- a/code/site/components/com_pages/model/filesystem.php
+++ b/code/site/components/com_pages/model/filesystem.php
@@ -123,12 +123,15 @@ class ComPagesModelFilesystem extends ComPagesModelCollection
 
                     if($identity_key)
                     {
-                        $identity = $this->createIdentity();
-                        $data[$identity] = [$identity_key => $identity] + $values;
+                        if(!$key)
+                        {
+                            $key = $this->createIdentity();
+                            $entity->setProperty($identity_key, $key, false);
+                        }
 
-                        //Set the identity in the entity
-                        $entity->setProperty($identity_key, $identity, false);
+                        $data[$key] = [$identity_key => $key] + $values;
                     }
+                    else $data[] = $values;
 
                     $result = self::PERSIST_SUCCESS;
                 }


### PR DESCRIPTION
This PR closes #515 and fixes an issue with a filesystem model always creating an identity key value even if the key exists in the entity.